### PR TITLE
feat: clipboard image paste + unify claude model picker

### DIFF
--- a/src/electron/ipc-handlers.ts
+++ b/src/electron/ipc-handlers.ts
@@ -2179,6 +2179,49 @@ async function toProjectAttachment(cwd: string, filePath: string): Promise<Attac
   }
 }
 
+async function createInlineImageAttachment(
+  mimeType: string,
+  data: Uint8Array | ArrayBuffer | Buffer
+): Promise<Attachment | null> {
+  const normalizedMime = (mimeType || '').toLowerCase();
+  let ext: string;
+  if (normalizedMime === 'image/png') {
+    ext = '.png';
+  } else if (normalizedMime === 'image/jpeg' || normalizedMime === 'image/jpg') {
+    ext = '.jpg';
+  } else {
+    return null;
+  }
+
+  let buffer: Buffer;
+  if (Buffer.isBuffer(data)) {
+    buffer = data;
+  } else if (data instanceof Uint8Array) {
+    buffer = Buffer.from(data);
+  } else if (data instanceof ArrayBuffer) {
+    buffer = Buffer.from(new Uint8Array(data));
+  } else {
+    return null;
+  }
+
+  if (buffer.length === 0 || buffer.length > MAX_ATTACHMENT_BYTES) {
+    return null;
+  }
+
+  const baseDir = resolve(app.getPath('temp'), 'aegis-pasted-images');
+  const fileName = `pasted-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${ext}`;
+  const targetPath = resolve(baseDir, fileName);
+
+  try {
+    await fsPromises.mkdir(baseDir, { recursive: true });
+    await fsPromises.writeFile(targetPath, buffer);
+  } catch {
+    return null;
+  }
+
+  return toAttachment(targetPath);
+}
+
 async function createInlineTextAttachment(cwd: string, text: string): Promise<Attachment | null> {
   const normalizedCwd = cwd?.trim();
   const normalizedText = text ?? '';
@@ -3041,6 +3084,17 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
 
     return createInlineTextAttachment(cwd, text);
   });
+
+  // RPC: 把剪贴板中的图片（PNG/JPEG 二进制）写入临时文件并返回 Attachment
+  ipcMainHandle(
+    'create-inline-image-attachment',
+    async (_event, mimeType: string, data: Uint8Array | ArrayBuffer) => {
+      if (!mimeType || !data) {
+        return null;
+      }
+      return createInlineImageAttachment(mimeType, data);
+    }
+  );
 
   // RPC: 读取项目文件预览（安全：仅允许 cwd 内的文件，<=5MB）
   ipcMainHandle(

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -289,6 +289,10 @@ contextBridge.exposeInMainWorld('electron', {
     return ipcRenderer.invoke('create-inline-text-attachment', cwd, text);
   },
 
+  createInlineImageAttachment: (mimeType: string, data: Uint8Array) => {
+    return ipcRenderer.invoke('create-inline-image-attachment', mimeType, data);
+  },
+
   // 保存项目文本文件（仅 .txt）
   writeProjectTextFile: (cwd: string, filePath: string, content: string) => {
     return ipcRenderer.invoke('write-project-text-file', cwd, filePath, content);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -101,6 +101,7 @@ declare global {
     readProjectFilePreview: (cwd: string, filePath: string) => Promise<unknown>;
     createProjectAttachment: (cwd: string, filePath: string) => Promise<Attachment | null>;
     createInlineTextAttachment: (cwd: string, text: string) => Promise<Attachment | null>;
+    createInlineImageAttachment: (mimeType: string, data: Uint8Array) => Promise<Attachment | null>;
     writeProjectTextFile: (cwd: string, filePath: string, content: string) => Promise<{ ok: boolean; message?: string }>;
     previewArtifactPath: (cwd: string, filePath: string, options?: { openInBrowser?: boolean }) => Promise<{ ok: boolean; url?: string; message?: string }>;
     openPath: (filePath: string) => Promise<{ ok: boolean; message?: string }>;

--- a/src/ui/components/AgentModelPicker.tsx
+++ b/src/ui/components/AgentModelPicker.tsx
@@ -200,6 +200,16 @@ export function AgentModelPicker({
       if (currentCompatibleOption) {
         return `${currentCompatibleOption.label} · ${currentCompatibleOption.model}`;
       }
+      const normalizedDefaultModel = canonicalizeClaudeModel(claudeModel.config.defaultModel);
+      if (
+        normalizedDefaultModel &&
+        resolvedClaudeValue === normalizedDefaultModel &&
+        !currentCompatibleOption
+      ) {
+        const suffix =
+          claudeModel.context1m && supportsClaude1mContext(resolvedClaudeValue) ? ' (1M context)' : '';
+        return `Default${suffix}`;
+      }
       return resolvedClaudeValue
         ? formatClaudeModelLabel(resolvedClaudeValue, claudeModel.context1m)
         : currentProvider.label;
@@ -264,44 +274,32 @@ export function AgentModelPicker({
           option.model.toLowerCase().includes(normalizedModelSearchQuery)
         );
       });
-      const hasResults =
-        defaultMatchesSearch ||
-        filteredClaudePrimaryOptions.length > 0 ||
-        filteredCompatibleOptions.length > 0;
+      const hasClaudeCodeItems =
+        (normalizedDefaultModel && defaultMatchesSearch) || filteredClaudePrimaryOptions.length > 0;
+      const hasResults = hasClaudeCodeItems || filteredCompatibleOptions.length > 0;
 
       return (
         <>
-          {normalizedDefaultModel && defaultMatchesSearch && (
-            <>
-              <div className="px-2 py-1 text-[10px] font-medium text-[var(--text-muted)]">
-                Default · ~/.claude/settings.json
-              </div>
-              <button
-                key={`default-${normalizedDefaultModel}`}
-                onClick={() => {
-                  claudeModel.onChange(normalizedDefaultModel, null);
-                  setOpen(false);
-                }}
-                className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-2 text-left text-[12px] text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-tertiary)]"
-                title={normalizedDefaultModel}
-              >
-                <div className="min-w-0 truncate">
-                  {formatClaudeModelLabel(normalizedDefaultModel, claudeModel.context1m)}
-                </div>
-                {resolvedValue === normalizedDefaultModel && (
-                  <Check className="h-4 w-4 flex-shrink-0 text-[var(--text-secondary)]" />
-                )}
-              </button>
-            </>
-          )}
-          {filteredClaudePrimaryOptions.length > 0 && (
-            <div
-              className={`px-2 py-1 text-[10px] font-medium text-[var(--text-muted)] ${
-                normalizedDefaultModel && defaultMatchesSearch ? 'mt-2 border-t border-[var(--border)] pt-2' : ''
-              }`}
-            >
+          {hasClaudeCodeItems && (
+            <div className="px-2 py-1 text-[10px] font-medium text-[var(--text-muted)]">
               Claude Code
             </div>
+          )}
+          {normalizedDefaultModel && defaultMatchesSearch && (
+            <button
+              key={`default-${normalizedDefaultModel}`}
+              onClick={() => {
+                claudeModel.onChange(normalizedDefaultModel, null);
+                setOpen(false);
+              }}
+              className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-2 text-left text-[12px] text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-tertiary)]"
+              title={normalizedDefaultModel}
+            >
+              <div className="min-w-0 truncate">Default</div>
+              {resolvedValue === normalizedDefaultModel && (
+                <Check className="h-4 w-4 flex-shrink-0 text-[var(--text-secondary)]" />
+              )}
+            </button>
           )}
           {filteredClaudePrimaryOptions.map((model) => (
             <button

--- a/src/ui/components/ComposerPromptEditor.tsx
+++ b/src/ui/components/ComposerPromptEditor.tsx
@@ -24,6 +24,12 @@ export interface ComposerPasteContext {
   end: number;
 }
 
+export interface ComposerPasteImage {
+  mimeType: string;
+  data: Uint8Array;
+  name?: string;
+}
+
 function basenameOfPath(path: string): string {
   const normalized = path.replace(/\\/g, '/');
   const parts = normalized.split('/');
@@ -288,6 +294,7 @@ export const ComposerPromptEditor = forwardRef<
     cursorIndex: number;
     onChange: (value: string, cursorIndex: number) => void;
     onPasteText?: (context: ComposerPasteContext) => boolean | void;
+    onPasteImages?: (images: ComposerPasteImage[]) => boolean | void;
     onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
     onCompositionStart?: () => void;
     onCompositionEnd?: () => void;
@@ -371,6 +378,44 @@ export const ComposerPromptEditor = forwardRef<
 
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
     if (props.disabled) return;
+
+    const imageFiles: File[] = [];
+    const dt = event.clipboardData;
+    if (dt) {
+      if (dt.files && dt.files.length > 0) {
+        for (let i = 0; i < dt.files.length; i += 1) {
+          const f = dt.files.item(i);
+          if (f && /^image\/(png|jpe?g)$/i.test(f.type)) {
+            imageFiles.push(f);
+          }
+        }
+      }
+      if (imageFiles.length === 0 && dt.items && dt.items.length > 0) {
+        for (let i = 0; i < dt.items.length; i += 1) {
+          const item = dt.items[i];
+          if (item.kind === 'file' && /^image\/(png|jpe?g)$/i.test(item.type)) {
+            const f = item.getAsFile();
+            if (f) imageFiles.push(f);
+          }
+        }
+      }
+    }
+
+    if (imageFiles.length > 0 && props.onPasteImages) {
+      event.preventDefault();
+      void Promise.all(
+        imageFiles.map(async (file) => ({
+          mimeType: file.type.toLowerCase(),
+          data: new Uint8Array(await file.arrayBuffer()),
+          name: file.name || undefined,
+        }))
+      ).then((images) => {
+        const handled = props.onPasteImages?.(images);
+        void handled;
+      });
+      return;
+    }
+
     const text = event.clipboardData.getData('text/plain');
     if (!text) return;
     event.preventDefault();

--- a/src/ui/components/NewSessionView.tsx
+++ b/src/ui/components/NewSessionView.tsx
@@ -570,6 +570,49 @@ export function NewSessionView() {
     await autoConvertComposerTextToAttachment(value, nextCursorIndex);
   };
 
+  const handlePasteImages = useCallback(async (
+    images: { mimeType: string; data: Uint8Array; name?: string }[]
+  ): Promise<boolean> => {
+    if (pendingStart || images.length === 0) return false;
+
+    const created: Attachment[] = [];
+    let failed = 0;
+    for (const image of images) {
+      try {
+        const attachment = await window.electron.createInlineImageAttachment(
+          image.mimeType,
+          image.data
+        );
+        if (attachment) {
+          created.push(attachment);
+        } else {
+          failed += 1;
+        }
+      } catch {
+        failed += 1;
+      }
+    }
+
+    if (created.length > 0) {
+      setAttachments((prev) => {
+        const existingPaths = new Set(prev.map((a) => a.path));
+        const next = [...prev];
+        for (const a of created) {
+          if (!existingPaths.has(a.path)) {
+            next.push(a);
+          }
+        }
+        return next;
+      });
+    }
+
+    if (failed > 0) {
+      toast.error(`Failed to paste ${failed} image(s). Only PNG/JPEG up to 10MB are supported.`);
+    }
+
+    return created.length > 0;
+  }, [pendingStart]);
+
   const handleLongPaste = useCallback(async (
     context: { text: string; start: number; end: number }
   ): Promise<boolean> => {
@@ -788,6 +831,9 @@ export function NewSessionView() {
                 }}
                 onPasteText={(context) => {
                   void handleLongPaste(context);
+                }}
+                onPasteImages={(images) => {
+                  void handlePasteImages(images);
                 }}
                 onCompositionStart={() => {
                   isComposingRef.current = true;

--- a/src/ui/components/PromptInput.tsx
+++ b/src/ui/components/PromptInput.tsx
@@ -770,6 +770,49 @@ export function PromptInput({ sessionId }: { sessionId?: string | null } = {}) {
     await autoConvertComposerTextToAttachment(value, nextCursorIndex);
   };
 
+  const handlePasteImages = useCallback(async (
+    images: { mimeType: string; data: Uint8Array; name?: string }[]
+  ): Promise<boolean> => {
+    if (isBusy || images.length === 0) return false;
+
+    const created: Attachment[] = [];
+    let failed = 0;
+    for (const image of images) {
+      try {
+        const attachment = await window.electron.createInlineImageAttachment(
+          image.mimeType,
+          image.data
+        );
+        if (attachment) {
+          created.push(attachment);
+        } else {
+          failed += 1;
+        }
+      } catch {
+        failed += 1;
+      }
+    }
+
+    if (created.length > 0) {
+      setAttachments((prev) => {
+        const existingPaths = new Set(prev.map((a) => a.path));
+        const next = [...prev];
+        for (const a of created) {
+          if (!existingPaths.has(a.path)) {
+            next.push(a);
+          }
+        }
+        return next;
+      });
+    }
+
+    if (failed > 0) {
+      toast.error(`Failed to paste ${failed} image(s). Only PNG/JPEG up to 10MB are supported.`);
+    }
+
+    return created.length > 0;
+  }, [isBusy]);
+
   const handleLongPaste = useCallback(async (
     context: { text: string; start: number; end: number }
   ): Promise<boolean> => {
@@ -922,6 +965,9 @@ export function PromptInput({ sessionId }: { sessionId?: string | null } = {}) {
             }}
             onPasteText={(context) => {
               void handleLongPaste(context);
+            }}
+            onPasteImages={(images) => {
+              void handlePasteImages(images);
             }}
             onCompositionStart={() => {
               isComposingRef.current = true;


### PR DESCRIPTION
## Summary

- **Clipboard image paste**: pasting a PNG/JPEG screenshot into the composer now attaches it as an image. New `create-inline-image-attachment` IPC writes the buffer to the OS temp dir and returns a standard `Attachment`, then both `PromptInput` and `NewSessionView` push it into their attachment lists. `ComposerPromptEditor` detects `image/png` and `image/jpeg` in `clipboardData.files` / `items` before falling back to the existing text-paste path.
- **Claude model picker cleanup**: merges the previously split model picker sections under a single "Claude Code" area and reworks the list around the user's actual selection.

## Commits

- `refactor: merge claude model picker sections under claude code`
- `feat: support pasting clipboard images as attachments`

## Test plan

- [ ] Cmd+V a macOS screenshot in the composer on a running session → image chip appears in attachments
- [ ] Cmd+V a screenshot in NewSessionView (no active session) → image chip appears
- [ ] Paste multiple images at once → all show up, de-duplicated by path
- [ ] Paste a non-image (plain text, long text, file path) → existing text/long-paste behavior unchanged
- [ ] Paste >10MB image → toast error, nothing added
- [ ] Claude model picker renders a single grouped section and selection persists


Made with [Cursor](https://cursor.com)