### PR TITLE
[codex] fix packaged Claude spawn path

### DIFF
--- a/src/electron/libs/claude-runtime-status.ts
+++ b/src/electron/libs/claude-runtime-status.ts
@@ -3,7 +3,11 @@ import { sep } from 'path';
 import type { ClaudeRuntimeSource, ClaudeRuntimeStatus } from '../../shared/types';
 import { getClaudeEnv, hasClaudeCodeOAuthAccount, sanitizeOfficialClaudeEnv } from './claude-settings';
 import { normalizeClaudeRequestedModel } from './claude-model-selection';
-import { getClaudeCodeRuntime, type ClaudeCodeRuntime } from './claude-runtime';
+import {
+  getClaudeCodeRuntime,
+  isClaudeCodeNativeExecutable,
+  type ClaudeCodeRuntime,
+} from './claude-runtime';
 
 const INSTALL_COMMAND = 'claude install stable';
 const LOGIN_COMMAND = 'claude auth login';
@@ -128,14 +132,20 @@ function execClaudeRuntimeCommand(
     });
   }
 
-  const commandArgs = runtime.pathToClaudeCodeExecutable
-    ? [...runtime.executableArgs, runtime.pathToClaudeCodeExecutable, ...args]
-    : [...runtime.executableArgs, ...args];
+  const nativeExecutable = isClaudeCodeNativeExecutable(runtime.pathToClaudeCodeExecutable)
+    ? runtime.pathToClaudeCodeExecutable
+    : undefined;
+  const command = nativeExecutable || runtime.executable;
+  const commandArgs = nativeExecutable
+    ? args
+    : runtime.pathToClaudeCodeExecutable
+      ? [...runtime.executableArgs, runtime.pathToClaudeCodeExecutable, ...args]
+      : [...runtime.executableArgs, ...args];
   const commandEnv = env || buildClaudeRuntimeEnv(runtime.env);
 
   return new Promise((resolve) => {
     execFile(
-      runtime.executable,
+      command,
       commandArgs,
       {
         env: commandEnv,

--- a/src/electron/libs/claude-runtime.ts
+++ b/src/electron/libs/claude-runtime.ts
@@ -192,6 +192,10 @@ function isNodeScriptPath(filePath: string | undefined): boolean {
   return lower.endsWith('.js') || lower.endsWith('.cjs') || lower.endsWith('.mjs');
 }
 
+export function isClaudeCodeNativeExecutable(filePath: string | undefined): boolean {
+  return Boolean(filePath && !isNodeScriptPath(filePath));
+}
+
 export function getClaudeCodeRuntime(): ClaudeCodeRuntime {
   const cliPath = resolveClaudeCodeCliPath();
   const env: Record<string, string | undefined> = {};
@@ -199,12 +203,12 @@ export function getClaudeCodeRuntime(): ClaudeCodeRuntime {
   let executableArgs: string[] = [];
   let pathToClaudeCodeExecutable = cliPath;
 
-  if (cliPath && !isNodeScriptPath(cliPath)) {
+  if (isClaudeCodeNativeExecutable(cliPath)) {
     return {
-      executable: cliPath,
+      executable,
       executableArgs: [],
       env: {},
-      pathToClaudeCodeExecutable: undefined,
+      pathToClaudeCodeExecutable,
     };
   }
 


### PR DESCRIPTION
## Summary

- pass the resolved Claude Code path to the Agent SDK even when it is a native executable
- keep native Claude runtime status checks executing the native binary directly
- avoid SDK fallback resolution into app.asar for packaged Electron builds

## Root Cause

The packaged app already includes Claude under app.asar.unpacked, but Aegis passed native Claude paths as the SDK executable instead of pathToClaudeCodeExecutable. That left pathToClaudeCodeExecutable empty, so the SDK resolved its own binary path inside app.asar. System spawn cannot execute through app.asar because it is a file, which produced spawn ENOTDIR.

## Validation

- npm run build
- git diff --check
- simulated packaged runtime resolution with PATH cleared and process.resourcesPath pointing at release/mac-arm64/Aegis.app/Contents/Resources; verified the resolved path uses app.asar.unpacked and not app.asar/node_modules
- ran release/mac-arm64/Aegis.app/Contents/Resources/app.asar.unpacked/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude --version
