### PR TITLE
[codex] add mdx split preview editor

### DIFF
--- a/src/electron/ipc-handlers.ts
+++ b/src/electron/ipc-handlers.ts
@@ -4290,7 +4290,9 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
         try {
           const text = await fsPromises.readFile(validation.targetReal, 'utf8');
           return {
-            kind: ext === '.md' || ext === '.mdx' ? 'markdown' : ext === '.html' || ext === '.htm' ? 'html' : 'text',
+            // MDX must stay on the raw text path: the Markdown rich editor
+            // serializes CommonMark/GFM and can rewrite MDX source.
+            kind: ext === '.md' ? 'markdown' : ext === '.html' || ext === '.htm' ? 'html' : 'text',
             path: validation.targetReal,
             name,
             ext,
@@ -4340,7 +4342,7 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
     }
   );
 
-  // RPC: 写入项目文本文件（当前允许写 .txt / .md，安全：cwd 内，<=5MB）
+  // RPC: 写入项目文本文件（当前允许写 .txt / .md / .mdx，安全：cwd 内，<=5MB）
   ipcMainHandle(
     'write-project-text-file',
     async (
@@ -4352,8 +4354,8 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
       const resolved = resolve(cwd || '.', filePath || '');
       const ext = extname(resolved).toLowerCase();
 
-      if (ext !== '.txt' && ext !== '.md') {
-        return { ok: false, message: 'Only .txt and .md files are editable right now.' };
+      if (ext !== '.txt' && ext !== '.md' && ext !== '.mdx') {
+        return { ok: false, message: 'Only .txt, .md, and .mdx files are editable right now.' };
       }
 
       const validation = await validateProjectFilePath(cwd, resolved);

--- a/src/electron/ipc-handlers.ts
+++ b/src/electron/ipc-handlers.ts
@@ -4260,6 +4260,7 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
       // Markdown + text-like preview
       if (
         ext === '.md' ||
+        ext === '.mdx' ||
         ext === '.txt' ||
         ext === '.json' ||
         ext === '.log' ||
@@ -4289,13 +4290,13 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
         try {
           const text = await fsPromises.readFile(validation.targetReal, 'utf8');
           return {
-            kind: ext === '.md' ? 'markdown' : ext === '.html' || ext === '.htm' ? 'html' : 'text',
+            kind: ext === '.md' || ext === '.mdx' ? 'markdown' : ext === '.html' || ext === '.htm' ? 'html' : 'text',
             path: validation.targetReal,
             name,
             ext,
             size: stat.size,
             text,
-            editable: ext === '.txt' || ext === '.md',
+            editable: ext === '.txt' || ext === '.md' || ext === '.mdx',
           };
         } catch (error) {
           return {

--- a/src/ui/components/HighlightedCode.tsx
+++ b/src/ui/components/HighlightedCode.tsx
@@ -61,6 +61,7 @@ function inferLanguage(fileName?: string): string | undefined {
     yml: 'yaml',
     yaml: 'yaml',
     md: 'markdown',
+    mdx: 'markdown',
     sql: 'sql',
     java: 'java',
     go: 'go',

--- a/src/ui/components/ProjectMdxPreview.tsx
+++ b/src/ui/components/ProjectMdxPreview.tsx
@@ -1,0 +1,479 @@
+import { useMemo } from 'react';
+import { MDContent } from '../render/markdown';
+
+type MdxFrontmatterFieldKind = 'boolean' | 'array' | 'number' | 'text';
+type MdxPreviewSegment =
+  | {
+      type: 'markdown';
+      key: string;
+      content: string;
+    }
+  | {
+      type: 'placeholder';
+      key: string;
+      line: number;
+      label: string;
+      detail: string;
+      status: 'missing' | 'disabled' | 'client' | 'error';
+      source: string;
+    };
+type MdxPlaceholderStatus = Extract<MdxPreviewSegment, { type: 'placeholder' }>['status'];
+
+export interface MdxFrontmatterField {
+  key: string;
+  value: string;
+  kind: MdxFrontmatterFieldKind;
+  line: number;
+}
+
+export interface MdxDocumentModel {
+  frontmatter: {
+    raw: string;
+    startLine: number;
+    endLine: number;
+    fields: MdxFrontmatterField[];
+    parseError: string | null;
+  } | null;
+  body: string;
+  segments: MdxPreviewSegment[];
+  issues: MdxPreviewSegment[];
+}
+
+const YAML_KEY_VALUE_RE = /^([A-Za-z0-9_.-]+):\s*(.*)$/;
+const MDX_IMPORT_EXPORT_RE = /^\s*(?:import|export)\s+/;
+const JSX_COMPONENT_RE = /^\s*<([A-Z][\w.]*)\b([^>]*)\/?>\s*$/;
+const JSX_LOWER_RE = /^\s*<[a-z][\w-]*\b[^>]*>\s*$/;
+const JSX_CLOSE_RE = /^\s*<\/([A-Za-z][\w.]*)>\s*$/;
+const JSX_EXPR_RE = /^\s*\{[\s\S]*\}\s*$/;
+
+function normalizeLineEndings(value: string): string {
+  return String(value || '').replace(/\r\n/g, '\n');
+}
+
+function detectFieldKind(value: string): MdxFrontmatterFieldKind {
+  const trimmed = value.trim();
+  if (/^(true|false)$/i.test(trimmed)) return 'boolean';
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return 'number';
+  if (/^\[[\s\S]*\]$/.test(trimmed)) return 'array';
+  return 'text';
+}
+
+function stripYamlQuote(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function formatYamlValue(value: string, kind: MdxFrontmatterFieldKind): string {
+  const trimmed = value.trim();
+  if (kind === 'boolean') {
+    return trimmed.toLowerCase() === 'true' ? 'true' : 'false';
+  }
+  if (kind === 'number' && /^-?\d+(?:\.\d+)?$/.test(trimmed)) {
+    return trimmed;
+  }
+  if (kind === 'array') {
+    const items = trimmed
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .map((item) => item.replace(/^['"]|['"]$/g, ''));
+    return `[${items.map((item) => JSON.stringify(item)).join(', ')}]`;
+  }
+  if (!trimmed) return '""';
+  if (/^(true|false|null|~|-?\d|\[|\{)/i.test(trimmed) || /[:#\n]/.test(trimmed)) {
+    return JSON.stringify(trimmed);
+  }
+  return trimmed;
+}
+
+function splitMdxFrontmatter(content: string) {
+  const text = normalizeLineEndings(content);
+  const lines = text.split('\n');
+
+  if (lines[0]?.trim() !== '---') {
+    return {
+      frontmatter: null,
+      body: text,
+      bodyStartLine: 1,
+    };
+  }
+
+  const endIndex = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
+  if (endIndex < 1) {
+    return {
+      frontmatter: {
+        raw: lines.slice(1).join('\n'),
+        startLine: 1,
+        endLine: lines.length,
+        fields: [] as MdxFrontmatterField[],
+        parseError: 'Missing closing frontmatter delimiter.',
+      },
+      body: '',
+      bodyStartLine: lines.length + 1,
+    };
+  }
+
+  const raw = lines.slice(1, endIndex).join('\n');
+  return {
+    frontmatter: {
+      raw,
+      startLine: 1,
+      endLine: endIndex + 1,
+      fields: parseFrontmatterFields(raw),
+      parseError: null,
+    },
+    body: lines.slice(endIndex + 1).join('\n'),
+    bodyStartLine: endIndex + 2,
+  };
+}
+
+function parseFrontmatterFields(raw: string): MdxFrontmatterField[] {
+  const fields: MdxFrontmatterField[] = [];
+  const lines = raw.split('\n');
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return;
+    const match = YAML_KEY_VALUE_RE.exec(line);
+    if (!match) return;
+    const value = match[2] ?? '';
+    fields.push({
+      key: match[1],
+      value: stripYamlQuote(value),
+      kind: detectFieldKind(value),
+      line: index + 2,
+    });
+  });
+
+  return fields;
+}
+
+function getPlaceholderStatus(source: string): MdxPlaceholderStatus {
+  if (/error|throw/i.test(source)) return 'error';
+  if (/client|browser|window\./i.test(source)) return 'client';
+  if (/disabled|hidden|draft/i.test(source)) return 'disabled';
+  return 'missing';
+}
+
+function isWrapperTag(label: string): boolean {
+  return /^(Fragment|Layout|Page|Provider|Providers|Wrapper|MDXLayout)$/.test(label);
+}
+
+function flushMarkdownSegment(
+  segments: MdxPreviewSegment[],
+  buffer: string[],
+  keyPrefix: string
+) {
+  const content = buffer.join('\n').trim();
+  if (!content) {
+    buffer.length = 0;
+    return;
+  }
+  segments.push({
+    type: 'markdown',
+    key: `${keyPrefix}-${segments.length}`,
+    content,
+  });
+  buffer.length = 0;
+}
+
+function buildMdxPreviewSegments(body: string, bodyStartLine: number): MdxPreviewSegment[] {
+  const segments: MdxPreviewSegment[] = [];
+  const markdownBuffer: string[] = [];
+  const lines = normalizeLineEndings(body).split('\n');
+
+  lines.forEach((line, index) => {
+    const lineNo = bodyStartLine + index;
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      markdownBuffer.push(line);
+      return;
+    }
+
+    if (MDX_IMPORT_EXPORT_RE.test(trimmed)) {
+      flushMarkdownSegment(segments, markdownBuffer, 'mdx-md');
+      segments.push({
+        type: 'placeholder',
+        key: `mdx-runtime-${lineNo}`,
+        line: lineNo,
+        label: trimmed.startsWith('import') ? 'import' : 'export',
+        detail: 'Runtime statement hidden from the document preview.',
+        status: 'disabled',
+        source: trimmed,
+      });
+      return;
+    }
+
+    const closeMatch = JSX_CLOSE_RE.exec(trimmed);
+    if (closeMatch && isWrapperTag(closeMatch[1])) {
+      return;
+    }
+
+    const componentMatch = JSX_COMPONENT_RE.exec(trimmed);
+    if (componentMatch) {
+      const label = componentMatch[1];
+      if (isWrapperTag(label)) {
+        return;
+      }
+      flushMarkdownSegment(segments, markdownBuffer, 'mdx-md');
+      segments.push({
+        type: 'placeholder',
+        key: `mdx-component-${lineNo}`,
+        line: lineNo,
+        label,
+        detail: 'MDX component cannot run inside this lightweight preview.',
+        status: getPlaceholderStatus(trimmed),
+        source: trimmed,
+      });
+      return;
+    }
+
+    if (JSX_EXPR_RE.test(trimmed) || JSX_LOWER_RE.test(trimmed)) {
+      flushMarkdownSegment(segments, markdownBuffer, 'mdx-md');
+      segments.push({
+        type: 'placeholder',
+        key: `mdx-expression-${lineNo}`,
+        line: lineNo,
+        label: JSX_EXPR_RE.test(trimmed) ? 'expression' : 'jsx',
+        detail: 'Inline JSX is shown as a source placeholder.',
+        status: getPlaceholderStatus(trimmed),
+        source: trimmed,
+      });
+      return;
+    }
+
+    markdownBuffer.push(line);
+  });
+
+  flushMarkdownSegment(segments, markdownBuffer, 'mdx-md');
+  return segments;
+}
+
+export function parseMdxDocument(content: string): MdxDocumentModel {
+  const parts = splitMdxFrontmatter(content);
+  const segments = buildMdxPreviewSegments(parts.body, parts.bodyStartLine);
+  const issues = segments.filter((segment): segment is Extract<MdxPreviewSegment, { type: 'placeholder' }> =>
+    segment.type === 'placeholder'
+  );
+
+  return {
+    frontmatter: parts.frontmatter,
+    body: parts.body,
+    segments,
+    issues,
+  };
+}
+
+export function updateMdxFrontmatterField(
+  content: string,
+  key: string,
+  value: string,
+  kind: MdxFrontmatterFieldKind
+): string {
+  const normalized = normalizeLineEndings(content);
+  const lines = normalized.split('\n');
+  const nextLine = `${key}: ${formatYamlValue(value, kind)}`;
+
+  if (lines[0]?.trim() !== '---') {
+    return `---\n${nextLine}\n---\n\n${normalized.replace(/^\n+/, '')}`;
+  }
+
+  const endIndex = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
+  if (endIndex < 1) {
+    return normalized;
+  }
+
+  for (let index = 1; index < endIndex; index += 1) {
+    const match = YAML_KEY_VALUE_RE.exec(lines[index]);
+    if (match?.[1] === key) {
+      const nextLines = [...lines];
+      nextLines[index] = nextLine;
+      return nextLines.join('\n');
+    }
+  }
+
+  const nextLines = [...lines];
+  nextLines.splice(endIndex, 0, nextLine);
+  return nextLines.join('\n');
+}
+
+function statusLabel(status: MdxPlaceholderStatus): string {
+  if (status === 'client') return 'client-only';
+  if (status === 'disabled') return 'disabled';
+  if (status === 'error') return 'error';
+  return 'missing';
+}
+
+export function ProjectMdxProperties({
+  content,
+  onChange,
+  onRevealSource,
+  compact = false,
+}: {
+  content: string;
+  onChange: (next: string) => void;
+  onRevealSource?: (line: number) => void;
+  compact?: boolean;
+}) {
+  const model = useMemo(() => parseMdxDocument(content), [content]);
+  const frontmatter = model.frontmatter;
+  const fields = frontmatter?.fields ?? [];
+
+  if (!frontmatter && compact) {
+    return null;
+  }
+
+  return (
+    <section className={`aegis-mdx-properties ${compact ? 'aegis-mdx-properties-compact' : ''}`}>
+      <div className="aegis-mdx-properties-header">
+        <span className="aegis-mdx-properties-title">Properties</span>
+        {frontmatter ? (
+          <span className="aegis-mdx-properties-count">{fields.length} fields</span>
+        ) : (
+          <span className="aegis-mdx-properties-count">no frontmatter</span>
+        )}
+      </div>
+
+      {frontmatter?.parseError ? (
+        <button
+          type="button"
+          className="aegis-mdx-properties-warning"
+          onClick={() => onRevealSource?.(frontmatter.endLine)}
+        >
+          {frontmatter.parseError}
+        </button>
+      ) : null}
+
+      {fields.length > 0 ? (
+        <div className="aegis-mdx-properties-grid">
+          {fields.slice(0, compact ? 6 : 12).map((field) => {
+            const inputId = `mdx-prop-${field.line}-${field.key}`;
+            return (
+              <div key={`${field.key}-${field.line}`} className="aegis-mdx-property-row">
+                <button
+                  type="button"
+                  className="aegis-mdx-property-key"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    onRevealSource?.(field.line);
+                  }}
+                  title={`Reveal ${field.key} at line ${field.line}`}
+                >
+                  {field.key}
+                </button>
+                {field.kind === 'boolean' ? (
+                  <input
+                    id={inputId}
+                    type="checkbox"
+                    aria-label={field.key}
+                    checked={field.value.trim().toLowerCase() === 'true'}
+                    onChange={(event) =>
+                      onChange(updateMdxFrontmatterField(content, field.key, event.target.checked ? 'true' : 'false', field.kind))
+                    }
+                  />
+                ) : (
+                  <input
+                    id={inputId}
+                    type={field.kind === 'number' ? 'number' : 'text'}
+                    aria-label={field.key}
+                    value={field.kind === 'array' ? field.value.replace(/^\[|\]$/g, '') : field.value}
+                    onChange={(event) =>
+                      onChange(updateMdxFrontmatterField(content, field.key, event.target.value, field.kind))
+                    }
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="aegis-mdx-properties-empty">No editable metadata in this file.</div>
+      )}
+    </section>
+  );
+}
+
+function ProjectMdxPlaceholder({
+  segment,
+  onRevealSource,
+}: {
+  segment: Extract<MdxPreviewSegment, { type: 'placeholder' }>;
+  onRevealSource?: (line: number) => void;
+}) {
+  return (
+    <div className={`aegis-mdx-placeholder aegis-mdx-placeholder-${segment.status}`}>
+      <div className="aegis-mdx-placeholder-main">
+        <span className="aegis-mdx-placeholder-badge">{statusLabel(segment.status)}</span>
+        <span className="aegis-mdx-placeholder-title">{segment.label}</span>
+        <span className="aegis-mdx-placeholder-line">line {segment.line}</span>
+      </div>
+      <div className="aegis-mdx-placeholder-detail">{segment.detail}</div>
+      <code>{segment.source}</code>
+      {onRevealSource ? (
+        <button
+          type="button"
+          className="aegis-mdx-placeholder-reveal"
+          onClick={() => onRevealSource(segment.line)}
+        >
+          Reveal source
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export function ProjectMdxPreview({
+  content,
+  onChange,
+  onRevealSource,
+  showProperties = true,
+}: {
+  content: string;
+  onChange: (next: string) => void;
+  onRevealSource?: (line: number) => void;
+  showProperties?: boolean;
+}) {
+  const model = useMemo(() => parseMdxDocument(content), [content]);
+
+  return (
+    <div className="aegis-mdx-preview">
+      {showProperties ? (
+        <ProjectMdxProperties
+          content={content}
+          onChange={onChange}
+          onRevealSource={onRevealSource}
+        />
+      ) : null}
+
+      <div className="project-markdown-preview aegis-mdx-preview-body">
+        {model.segments.length > 0 ? (
+          model.segments.map((segment) =>
+            segment.type === 'markdown' ? (
+              <MDContent
+                key={segment.key}
+                content={segment.content}
+                allowHtml={false}
+                className="aegis-mdx-markdown-chunk"
+              />
+            ) : (
+              <ProjectMdxPlaceholder
+                key={segment.key}
+                segment={segment}
+                onRevealSource={onRevealSource}
+              />
+            )
+          )
+        ) : (
+          <div className="aegis-mdx-preview-empty">Nothing to preview yet.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/ProjectTextEditor.tsx
+++ b/src/ui/components/ProjectTextEditor.tsx
@@ -1,0 +1,313 @@
+import React, { useEffect, useRef } from 'react';
+import { EditorState, EditorSelection, Transaction } from '@codemirror/state';
+import {
+  EditorView,
+  keymap,
+  lineNumbers,
+  highlightActiveLine,
+  drawSelection,
+  KeyBinding,
+} from '@codemirror/view';
+import {
+  syntaxHighlighting,
+  defaultHighlightStyle,
+  bracketMatching,
+  indentOnInput,
+} from '@codemirror/language';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
+
+interface ProjectTextEditorProps {
+  value: string;
+  onChange?: (value: string) => void;
+  onSave?: () => void;
+  className?: string;
+  revealTarget?: { line: number; token: number } | null;
+}
+
+// Minimal undo/redo stack since @codemirror/commands is not a dependency
+class UndoManager {
+  private stack: string[] = [];
+  private index = -1;
+  private maxSize = 200;
+
+  push(state: string) {
+    // Trim future redo entries
+    this.stack = this.stack.slice(0, this.index + 1);
+    this.stack.push(state);
+    this.index = this.stack.length - 1;
+    if (this.stack.length > this.maxSize) {
+      this.stack.shift();
+      this.index--;
+    }
+  }
+
+  undo(current: string): string | null {
+    if (this.index <= 0) return null;
+    // If the current document doesn't match the top of stack, push it first
+    if (this.stack[this.index] !== current) {
+      this.push(current);
+      this.index--; // skip the newly pushed entry
+    } else {
+      this.index--;
+    }
+    return this.stack[this.index];
+  }
+
+  redo(): string | null {
+    if (this.index >= this.stack.length - 1) return null;
+    this.index++;
+    return this.stack[this.index];
+  }
+
+  clear() {
+    this.stack = [];
+    this.index = -1;
+  }
+}
+
+export const ProjectTextEditor: React.FC<ProjectTextEditorProps> = ({
+  value,
+  onChange,
+  onSave,
+  className,
+  revealTarget,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const onChangeRef = useRef(onChange);
+  const onSaveRef = useRef(onSave);
+  const isInternalChangeRef = useRef(false);
+  const undoManagerRef = useRef(new UndoManager());
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const um = undoManagerRef.current;
+
+    const updateListener = EditorView.updateListener.of((update) => {
+      if (update.docChanged) {
+        isInternalChangeRef.current = true;
+        const newValue = update.state.doc.toString();
+        // Push to undo stack (debounce: only for user-initiated changes)
+        if (!update.transactions.some((tr) => tr.annotation(Transaction.userEvent) === 'undo-redo')) {
+          um.push(newValue);
+        }
+        onChangeRef.current?.(newValue);
+        isInternalChangeRef.current = false;
+      }
+    });
+
+    const customKeymap: readonly KeyBinding[] = [
+      {
+        key: 'Mod-s',
+        run: () => {
+          onSaveRef.current?.();
+          return true;
+        },
+        preventDefault: true,
+      },
+      {
+        key: 'Mod-z',
+        run: (view: EditorView) => {
+          const current = view.state.doc.toString();
+          const prev = um.undo(current);
+          if (prev !== null) {
+            view.dispatch({
+              changes: { from: 0, to: current.length, insert: prev },
+              annotations: Transaction.userEvent.of('undo-redo'),
+            });
+          }
+          return true;
+        },
+        preventDefault: true,
+      },
+      {
+        key: 'Mod-Shift-z',
+        run: (view: EditorView) => {
+          const next = um.redo();
+          if (next !== null) {
+            view.dispatch({
+              changes: { from: 0, to: view.state.doc.toString().length, insert: next },
+              annotations: Transaction.userEvent.of('undo-redo'),
+            });
+          }
+          return true;
+        },
+        preventDefault: true,
+      },
+      {
+        key: 'Mod-y',
+        run: (view: EditorView) => {
+          const next = um.redo();
+          if (next !== null) {
+            view.dispatch({
+              changes: { from: 0, to: view.state.doc.toString().length, insert: next },
+              annotations: Transaction.userEvent.of('undo-redo'),
+            });
+          }
+          return true;
+        },
+        preventDefault: true,
+      },
+      {
+        key: 'Tab',
+        run: (view: EditorView) => {
+          // Insert 2 spaces at cursor or indent selected lines
+          const { state } = view;
+          const indent = '  ';
+          view.dispatch(
+            state.changeByRange((range) => {
+              if (range.empty) {
+                return { changes: [{ from: range.from, insert: indent }], range: EditorSelection.cursor(range.from + indent.length) };
+              }
+              // Multi-line selection: indent each line
+              const fromLine = state.doc.lineAt(range.from).number;
+              const toLine = state.doc.lineAt(range.to).number;
+              const cb: { from: number; to: number; insert: string }[] = [];
+              for (let i = fromLine; i <= toLine; i++) {
+                const line = state.doc.line(i);
+                cb.push({ from: line.from, to: line.from, insert: indent });
+              }
+              return { changes: cb, range };
+            }),
+          );
+          return true;
+        },
+        preventDefault: true,
+      },
+      {
+        key: 'Shift-Tab',
+        run: (view: EditorView) => {
+          // Remove up to 2 spaces from start of selected lines
+          const { state } = view;
+          view.dispatch(
+            state.changeByRange((range) => {
+              const doc = state.doc;
+              const fromLine = doc.lineAt(range.from);
+              const toLine = doc.lineAt(range.to);
+              const changes: { from: number; to: number; insert: string }[] = [];
+              for (let i = fromLine.number; i <= toLine.number; i++) {
+                const line = doc.line(i);
+                const text = line.text;
+                const leading = text.match(/^ {1,2}/);
+                if (leading) {
+                  changes.push({ from: line.from, to: line.from + leading[0].length, insert: '' });
+                }
+              }
+              return changes.length > 0 ? { range, changes } : { range };
+            }),
+          );
+          return true;
+        },
+        preventDefault: true,
+      },
+    ];
+
+    const extensions = [
+      lineNumbers(),
+      highlightActiveLine(),
+      drawSelection(),
+      bracketMatching(),
+      indentOnInput(),
+      syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+      keymap.of(customKeymap),
+      updateListener,
+      EditorView.lineWrapping,
+      markdown({
+        base: markdownLanguage,
+        codeLanguages: languages,
+      }),
+      EditorView.theme({
+        '&': {
+          height: '100%',
+        },
+        '.cm-scroller': {
+          overflow: 'auto',
+          fontFamily:
+            'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          fontSize: '14px',
+        },
+        '.cm-content': {
+          padding: '12px',
+          caretColor: 'var(--text-primary)',
+        },
+        '.cm-gutters': {
+          borderRight: '1px solid var(--border)',
+          backgroundColor: 'var(--panel-bg)',
+          color: 'var(--text-muted)',
+        },
+        '.cm-activeLine': {
+          backgroundColor: 'var(--hover-bg)',
+        },
+        '.cm-activeLineGutter': {
+          backgroundColor: 'var(--hover-bg)',
+        },
+      }),
+    ];
+
+    const state = EditorState.create({
+      doc: value,
+      extensions,
+    });
+
+    const view = new EditorView({
+      state,
+      parent: containerRef.current,
+    });
+
+    viewRef.current = view;
+    um.push(value); // initial state
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync external value changes (e.g., file reload from disk)
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || isInternalChangeRef.current) return;
+    const currentValue = view.state.doc.toString();
+    if (value !== currentValue) {
+      view.dispatch({
+        changes: {
+          from: 0,
+          to: currentValue.length,
+          insert: value,
+        },
+      });
+      undoManagerRef.current.clear();
+      undoManagerRef.current.push(value);
+    }
+  }, [value]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || !revealTarget) return;
+
+    const lineNumber = Math.max(1, Math.min(revealTarget.line, view.state.doc.lines));
+    const line = view.state.doc.line(lineNumber);
+    view.dispatch({
+      selection: EditorSelection.cursor(line.from),
+      effects: EditorView.scrollIntoView(line.from, { y: 'center' }),
+    });
+    view.focus();
+  }, [revealTarget]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`aegis-text-codemirror-host h-full ${className ?? ''}`}
+    />
+  );
+};

--- a/src/ui/components/ProjectTreePanel.tsx
+++ b/src/ui/components/ProjectTreePanel.tsx
@@ -9,6 +9,8 @@ import { HighlightedCode } from './HighlightedCode';
 import TextFileReader from './TextFileReader';
 import { FileTypeIcon } from './FileTypeIcon';
 import { ProjectMarkdownEditor } from './ProjectMarkdownEditor';
+import { ProjectMdxPreview, ProjectMdxProperties, parseMdxDocument } from './ProjectMdxPreview';
+import { ProjectTextEditor } from './ProjectTextEditor';
 import { IconButton } from './ui/icon-button';
 import { isHtmlFilePath, openHtmlFileInBrowserTab } from '../utils/html-preview';
 import {
@@ -24,6 +26,7 @@ import {
 import type { ProjectTreeNode } from '../types';
 
 type ProjectPanelTab = 'files' | 'changes';
+type ViewMode = 'view' | 'code' | 'split';
 type ProjectPanelDimensions = {
   defaultWidth: number;
   minWidth: number;
@@ -549,7 +552,9 @@ export function ProjectTreePanel({
   const [selectedFileCwd, setSelectedFileCwd] = useState<string | null>(null);
   const [selectedPreview, setSelectedPreview] = useState<ProjectFilePreview | null>(null);
   const [pptxSlideIndex, setPptxSlideIndex] = useState(0);
-  const [viewMode, setViewMode] = useState<'view' | 'code'>('view');
+  const [viewMode, setViewMode] = useState<ViewMode>('view');
+  const [mdxRevealTarget, setMdxRevealTarget] = useState<{ line: number; token: number } | null>(null);
+  const mdxRevealTokenRef = useRef(0);
   const [previewLoading, setPreviewLoading] = useState(false);
   const previewRequestIdRef = useRef(0);
   const [draftText, setDraftText] = useState('');
@@ -803,6 +808,7 @@ export function ProjectTreePanel({
     setSelectedFileCwd(null);
     setSelectedPreview(null);
     setViewMode('view');
+    setMdxRevealTarget(null);
     setPreviewLoading(false);
     setDraftText('');
     setSaveState('idle');
@@ -905,6 +911,7 @@ export function ProjectTreePanel({
       setSelectedFilePath(null);
       setSelectedFileCwd(null);
       setSelectedPreview(null);
+      setMdxRevealTarget(null);
       return;
     }
 
@@ -917,6 +924,7 @@ export function ProjectTreePanel({
       setSelectedFileCwd(null);
       setPreviewLoading(false);
       setSelectedPreview(null);
+      setMdxRevealTarget(null);
       setDraftText('');
       setSaveState('idle');
       setSaveError(null);
@@ -948,6 +956,7 @@ export function ProjectTreePanel({
     setSelectedFileCwd(cwd);
     expandParentsForPath(filePath);
     setViewMode('view');
+    setMdxRevealTarget(null);
     setPreviewLoading(true);
     setSelectedPreview(null);
     setDraftText('');
@@ -975,6 +984,11 @@ export function ProjectTreePanel({
       const preview = (await reader(cwd, filePath)) as ProjectFilePreview;
       if (previewRequestIdRef.current !== requestId) return;
       setSelectedPreview(preview);
+      if (preview.kind === 'text' && preview.ext === '.mdx') {
+        setDraftText(preview.text);
+        setViewMode('code');
+        return;
+      }
       if ((preview.kind === 'text' || preview.kind === 'markdown') && preview.editable) {
         setDraftText(preview.text);
       }
@@ -1290,6 +1304,7 @@ export function ProjectTreePanel({
     setSelectedFilePath(filePath);
     setSelectedFileCwd(fileCwd);
     setViewMode('view');
+    setMdxRevealTarget(null);
     setPreviewLoading(true);
     setSelectedPreview(null);
     setDraftText('');
@@ -1302,6 +1317,20 @@ export function ProjectTreePanel({
     try {
       const preview = (await reader(fileCwd, filePath)) as ProjectFilePreview;
       if (previewRequestIdRef.current !== requestId) return;
+      // MDX files: use CodeMirror plain-text editor (default), with toggle to rendered preview.
+      if (preview.kind === 'text' && preview.ext === '.mdx') {
+        setSelectedPreview(preview);
+        setDraftText(preview.text);
+        setViewMode('code'); // default to source editing like Cursor
+        if (typeof options.lineStart === 'number') {
+          mdxRevealTokenRef.current += 1;
+          setMdxRevealTarget({
+            line: options.lineStart,
+            token: mdxRevealTokenRef.current,
+          });
+        }
+        return;
+      }
       if (preview.kind === 'markdown') {
         setSelectedPreview(preview);
         if (preview.editable) {
@@ -1326,7 +1355,7 @@ export function ProjectTreePanel({
         });
         return;
       }
-      if (preview.kind === 'text' || preview.kind === 'markdown' || preview.kind === 'html') {
+      if (preview.kind === 'text' || preview.kind === 'html') {
         setSelectedPreview({ ...preview, editable: false });
         return;
       }
@@ -1352,6 +1381,7 @@ export function ProjectTreePanel({
     setSelectedFileCwd(null);
     setSelectedPreview(null);
     setViewMode('view');
+    setMdxRevealTarget(null);
     setDraftText('');
     setSaveState('idle');
     setSaveError(null);
@@ -1517,20 +1547,22 @@ export function ProjectTreePanel({
     };
   }, [collapsed, selectedFilePath, previewPanelWidth]);
 
+  const selectedEditableTextPreview =
+    selectedPreview &&
+    (selectedPreview.kind === 'markdown' ||
+      (selectedPreview.kind === 'text' && selectedPreview.ext === '.mdx')) &&
+    selectedPreview.editable
+      ? selectedPreview
+      : null;
+
   const canSaveText =
     !!selectedFileCwd &&
-    !!selectedPreview &&
-    (selectedPreview.kind === 'text' || selectedPreview.kind === 'markdown') &&
-    selectedPreview.editable &&
-    draftText !== selectedPreview.text;
+    !!selectedEditableTextPreview &&
+    draftText !== selectedEditableTextPreview.text;
 
   const handleSaveText = async () => {
     if (!selectedFileCwd) return;
-    if (
-      !selectedPreview ||
-      (selectedPreview.kind !== 'text' && selectedPreview.kind !== 'markdown') ||
-      !selectedPreview.editable
-    ) {
+    if (!selectedEditableTextPreview) {
       return;
     }
     if (!selectedFilePath) return;
@@ -1549,7 +1581,7 @@ export function ProjectTreePanel({
         setSaveError(result?.message || 'Failed to save');
         return;
       }
-      setSelectedPreview({ ...selectedPreview, text: draftText });
+      setSelectedPreview({ ...selectedEditableTextPreview, text: draftText });
       setExternalDiskText(null);
       void loadChangeRecords();
       setSaveState('saved');
@@ -1584,9 +1616,7 @@ export function ProjectTreePanel({
       !cwd ||
       !selectedFileCwd ||
       !selectedFilePath ||
-      !selectedPreview ||
-      selectedPreview.kind !== 'markdown' ||
-      !selectedPreview.editable
+      !selectedEditableTextPreview
     ) {
       return;
     }
@@ -1598,10 +1628,17 @@ export function ProjectTreePanel({
       void (async () => {
         try {
           const latest = (await reader(selectedFileCwd, selectedFilePath)) as ProjectFilePreview;
-          if (latest.kind !== 'markdown' || !latest.editable) return;
-          if (latest.text === selectedPreview.text) return;
+          if (
+            (latest.kind !== 'markdown' && latest.kind !== 'text') ||
+            !latest.editable ||
+            latest.kind !== selectedEditableTextPreview.kind ||
+            latest.ext !== selectedEditableTextPreview.ext
+          ) {
+            return;
+          }
+          if (latest.text === selectedEditableTextPreview.text) return;
 
-          if (draftText === selectedPreview.text) {
+          if (draftText === selectedEditableTextPreview.text) {
             setSelectedPreview(latest);
             setDraftText(latest.text);
             setExternalDiskText(null);
@@ -1615,18 +1652,17 @@ export function ProjectTreePanel({
     }, 4000);
 
     return () => window.clearInterval(intervalId);
-  }, [cwd, draftText, selectedFileCwd, selectedFilePath, selectedPreview]);
+  }, [cwd, draftText, selectedEditableTextPreview, selectedFileCwd, selectedFilePath]);
 
   const handleReloadMarkdownExternal = () => {
     if (
-      !selectedPreview ||
-      selectedPreview.kind !== 'markdown' ||
+      !selectedEditableTextPreview ||
       externalDiskText === null
     ) {
       return;
     }
 
-    setSelectedPreview({ ...selectedPreview, text: externalDiskText });
+    setSelectedPreview({ ...selectedEditableTextPreview, text: externalDiskText });
     setDraftText(externalDiskText);
     setExternalDiskText(null);
     setSaveState('idle');
@@ -1635,14 +1671,13 @@ export function ProjectTreePanel({
 
   const handleKeepMarkdownLocal = () => {
     if (
-      !selectedPreview ||
-      selectedPreview.kind !== 'markdown' ||
+      !selectedEditableTextPreview ||
       externalDiskText === null
     ) {
       return;
     }
 
-    setSelectedPreview({ ...selectedPreview, text: externalDiskText });
+    setSelectedPreview({ ...selectedEditableTextPreview, text: externalDiskText });
     setExternalDiskText(null);
     setSaveState('idle');
     setSaveError(null);
@@ -1763,8 +1798,12 @@ export function ProjectTreePanel({
     (
       (selectedPreview.kind === 'markdown' && viewMode === 'code') ||
       (selectedPreview.kind === 'html' && viewMode === 'code') ||
-      (selectedPreview.kind === 'text' && !selectedPreview.editable)
+      (selectedPreview.kind === 'text' && !selectedPreview.editable && selectedPreview.ext !== '.mdx')
     );
+  const isMdxFilePreview =
+    !previewLoading &&
+    selectedPreview?.kind === 'text' &&
+    selectedPreview.ext === '.mdx';
   const isMarkdownCodePreviewSurface =
     !previewLoading &&
     selectedPreview?.kind === 'markdown' &&
@@ -1773,6 +1812,32 @@ export function ProjectTreePanel({
     !previewLoading &&
     selectedPreview?.kind === 'markdown' &&
     viewMode === 'view';
+  const isMdxCodePreviewSurface =
+    isMdxFilePreview &&
+    viewMode === 'code';
+  const isMdxPreviewSurface =
+    isMdxFilePreview &&
+    viewMode === 'view';
+  const isMdxSplitPreviewSurface =
+    isMdxFilePreview &&
+    viewMode === 'split';
+  const mdxDocumentModel = useMemo(
+    () => (isMdxFilePreview ? parseMdxDocument(draftText) : null),
+    [draftText, isMdxFilePreview]
+  );
+  const mdxIssueCount =
+    (mdxDocumentModel?.issues.length ?? 0) +
+    (mdxDocumentModel?.frontmatter?.parseError ? 1 : 0);
+
+  const handleRevealMdxSource = useCallback((line: number) => {
+    mdxRevealTokenRef.current += 1;
+    setMdxRevealTarget({
+      line,
+      token: mdxRevealTokenRef.current,
+    });
+    setViewMode((current) => (current === 'split' ? 'split' : 'code'));
+  }, []);
+
   const isEditableMarkdownPreview =
     isMarkdownPreviewSurface &&
     selectedPreview?.editable &&
@@ -2193,61 +2258,77 @@ export function ProjectTreePanel({
                   </div>
 
                   <div className="flex items-center gap-1 flex-shrink-0 no-drag">
-                  {selectedPreview?.kind === 'html' && (
-                    <ViewModeToggle value={viewMode} onChange={setViewMode} />
-                  )}
+                    {(selectedPreview?.kind === 'html' || isMdxFilePreview) && (
+                      <ViewModeToggle
+                        value={viewMode}
+                        onChange={setViewMode}
+                        options={
+                          isMdxFilePreview
+                            ? [
+                                { value: 'code', label: 'Source', title: 'Edit source' },
+                                { value: 'view', label: 'Preview', title: 'Preview MDX' },
+                                { value: 'split', label: 'Split', title: 'Source and preview' },
+                              ]
+                            : undefined
+                        }
+                      />
+                    )}
 
-                  {canSaveText && (
-                    <button
-                      onClick={handleSaveText}
-                      disabled={saveState === 'saving'}
-                      className="px-2 py-1 text-xs rounded-md bg-[var(--accent)] text-[var(--accent-foreground)] hover:bg-[var(--accent-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
-                      title="Save"
-                    >
-                      {saveState === 'saving'
-                        ? 'Saving...'
-                        : saveState === 'saved'
-                          ? 'Saved'
-                          : 'Save'}
-                    </button>
-                  )}
+                    {canSaveText && (
+                      <button
+                        onClick={handleSaveText}
+                        disabled={saveState === 'saving'}
+                        className="px-2 py-1 text-xs rounded-md bg-[var(--accent)] text-[var(--accent-foreground)] hover:bg-[var(--accent-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+                        title="Save"
+                      >
+                        {saveState === 'saving'
+                          ? 'Saving...'
+                          : saveState === 'saved'
+                            ? 'Saved'
+                            : 'Save'}
+                      </button>
+                    )}
 
-                  {onToggleFullscreen && (
+                    {onToggleFullscreen && (
+                      <IconButton
+                        onClick={onToggleFullscreen}
+                        tooltip={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen'}
+                        label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+                      >
+                        {isFullscreen ? (
+                          <Minimize2 className="w-4 h-4" />
+                        ) : (
+                          <Maximize2 className="w-4 h-4" />
+                        )}
+                      </IconButton>
+                    )}
                     <IconButton
-                      onClick={onToggleFullscreen}
-                      tooltip={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen'}
-                      label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+                      onClick={closePreview}
+                      label="Close preview"
                     >
-                      {isFullscreen ? (
-                        <Minimize2 className="w-4 h-4" />
-                      ) : (
-                        <Maximize2 className="w-4 h-4" />
-                      )}
+                      <X className="w-4 h-4" />
                     </IconButton>
-                  )}
-                  <IconButton
-                    onClick={closePreview}
-                    label="Close preview"
-                  >
-                    <X className="w-4 h-4" />
-                  </IconButton>
-                  <IconButton
-                    onClick={() => {
-                      const isTxt = selectedPreview?.name?.toLowerCase().endsWith('.txt');
-                      handleCopyPath(isTxt && selectedPreview?.text ? selectedPreview.text : selectedFilePath);
-                    }}
-                    tooltip={copiedPath ? 'Copied' : (selectedPreview?.name?.toLowerCase().endsWith('.txt') ? 'Copy content' : 'Copy path')}
-                    label={selectedPreview?.name?.toLowerCase().endsWith('.txt') ? 'Copy content' : 'Copy path'}
-                  >
-                    {copiedPath ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-                  </IconButton>
-                </div>
+                    <IconButton
+                      onClick={() => {
+                        const isTxt =
+                          selectedPreview?.kind === 'text' &&
+                          selectedPreview.name?.toLowerCase().endsWith('.txt');
+                        handleCopyPath(isTxt ? selectedPreview.text : selectedFilePath);
+                      }}
+                      tooltip={copiedPath ? 'Copied' : (selectedPreview?.name?.toLowerCase().endsWith('.txt') ? 'Copy content' : 'Copy path')}
+                      label={selectedPreview?.name?.toLowerCase().endsWith('.txt') ? 'Copy content' : 'Copy path'}
+                    >
+                      {copiedPath ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                    </IconButton>
+                  </div>
                 </div>
               )}
 
               <div
                 className={`flex-1 min-h-0 overflow-auto ${
                   isMarkdownCodePreviewSurface
+                    ? 'bg-[var(--bg-primary)] p-0'
+                    : isMdxFilePreview
                     ? 'bg-[var(--bg-primary)] p-0'
                     : isCodePreviewSurface
                     ? 'rounded-lg border border-[var(--border)] bg-[var(--code-block-bg)] p-0'
@@ -2347,7 +2428,71 @@ export function ProjectTreePanel({
 
                 {!previewLoading && selectedPreview?.kind === 'text' && (
                   <>
-                    {selectedPreview.editable ? (
+                    {isMdxCodePreviewSurface ? (
+                      <div className="aegis-mdx-editor-shell">
+                        <ProjectMdxProperties
+                          content={draftText}
+                          onChange={setDraftText}
+                          onRevealSource={handleRevealMdxSource}
+                          compact
+                        />
+                        <div className="aegis-mdx-source-fill">
+                          <ProjectTextEditor
+                            value={draftText}
+                            onChange={setDraftText}
+                            onSave={() => handleSaveText()}
+                            revealTarget={mdxRevealTarget}
+                          />
+                        </div>
+                        <MdxStatusBar
+                          dirty={canSaveText}
+                          saveState={saveState}
+                          saveError={saveError}
+                          issueCount={mdxIssueCount}
+                          externalChange={externalDiskText !== null}
+                        />
+                      </div>
+                    ) : isMdxPreviewSurface ? (
+                      <ProjectMdxPreview
+                        content={draftText}
+                        onChange={setDraftText}
+                        onRevealSource={handleRevealMdxSource}
+                      />
+                    ) : isMdxSplitPreviewSurface ? (
+                      <div className="aegis-mdx-split">
+                        <div className="aegis-mdx-split-pane aegis-mdx-split-source">
+                          <ProjectMdxProperties
+                            content={draftText}
+                            onChange={setDraftText}
+                            onRevealSource={handleRevealMdxSource}
+                            compact
+                          />
+                          <div className="aegis-mdx-source-fill">
+                            <ProjectTextEditor
+                              value={draftText}
+                              onChange={setDraftText}
+                              onSave={() => handleSaveText()}
+                              revealTarget={mdxRevealTarget}
+                            />
+                          </div>
+                          <MdxStatusBar
+                            dirty={canSaveText}
+                            saveState={saveState}
+                            saveError={saveError}
+                            issueCount={mdxIssueCount}
+                            externalChange={externalDiskText !== null}
+                          />
+                        </div>
+                        <div className="aegis-mdx-split-pane aegis-mdx-split-preview">
+                          <ProjectMdxPreview
+                            content={draftText}
+                            onChange={setDraftText}
+                            onRevealSource={handleRevealMdxSource}
+                            showProperties={false}
+                          />
+                        </div>
+                      </div>
+                    ) : selectedPreview.editable ? (
                       <textarea
                         value={draftText}
                         onChange={(e) => setDraftText(e.target.value)}
@@ -2692,37 +2837,70 @@ function formatBytes(bytes: number): string {
   return `${rounded} ${units[unit]}`;
 }
 
+function MdxStatusBar({
+  dirty,
+  saveState,
+  saveError,
+  issueCount,
+  externalChange,
+}: {
+  dirty: boolean;
+  saveState: 'idle' | 'saving' | 'saved' | 'error';
+  saveError: string | null;
+  issueCount: number;
+  externalChange: boolean;
+}) {
+  const saveLabel =
+    saveState === 'saving'
+      ? 'Saving'
+      : saveState === 'saved'
+        ? 'Saved'
+        : saveState === 'error'
+          ? 'Save failed'
+          : dirty
+            ? 'Unsaved'
+            : 'Saved';
+  const previewLabel = issueCount > 0 ? `${issueCount} degraded` : 'Preview ready';
+
+  return (
+    <div className="aegis-mdx-statusbar">
+      <span>MDX</span>
+      <span className={dirty || saveState === 'error' ? 'is-attention' : ''}>{saveLabel}</span>
+      <span className={issueCount > 0 ? 'is-attention' : ''}>{previewLabel}</span>
+      {externalChange ? <span className="is-attention">Disk changed</span> : null}
+      {saveError ? <span className="is-error">{saveError}</span> : null}
+    </div>
+  );
+}
+
 function ViewModeToggle({
   value,
   onChange,
+  options = [
+    { value: 'view', label: 'View', title: 'View' },
+    { value: 'code', label: 'Code', title: 'Code' },
+  ],
 }: {
-  value: 'view' | 'code';
-  onChange: (next: 'view' | 'code') => void;
+  value: ViewMode;
+  onChange: (next: ViewMode) => void;
+  options?: Array<{ value: ViewMode; label: string; title: string }>;
 }) {
   return (
     <div className="mr-1 flex items-center overflow-hidden rounded-lg border border-[var(--border)]">
-      <button
-        onClick={() => onChange('view')}
-        className={`px-2 py-1 text-xs ${
-          value === 'view'
-            ? 'bg-[var(--bg-tertiary)] text-[var(--text-primary)]'
-            : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
-        }`}
-        title="View"
-      >
-        View
-      </button>
-      <button
-        onClick={() => onChange('code')}
-        className={`px-2 py-1 text-xs ${
-          value === 'code'
-            ? 'bg-[var(--bg-tertiary)] text-[var(--text-primary)]'
-            : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
-        }`}
-        title="Code"
-      >
-        Code
-      </button>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          className={`px-2 py-1 text-xs ${
+            value === option.value
+              ? 'bg-[var(--bg-tertiary)] text-[var(--text-primary)]'
+              : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+          }`}
+          title={option.title}
+        >
+          {option.label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -1416,6 +1416,295 @@ button.md-inline-file-code:hover {
   border-radius: 5px;
 }
 
+.aegis-text-codemirror-host {
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.aegis-text-codemirror-host .cm-editor {
+  height: 100%;
+  background: transparent;
+}
+
+.aegis-text-codemirror-host .cm-editor.cm-focused {
+  outline: none;
+}
+
+.aegis-text-codemirror-host .cm-line {
+  overflow-wrap: anywhere;
+}
+
+.aegis-mdx-editor-shell,
+.aegis-mdx-split {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.aegis-mdx-editor-shell {
+  flex-direction: column;
+}
+
+.aegis-mdx-source-fill {
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.aegis-mdx-split {
+  flex-direction: row;
+}
+
+.aegis-mdx-split-pane {
+  min-width: 0;
+  min-height: 0;
+  flex: 1 1 50%;
+  overflow: hidden;
+}
+
+.aegis-mdx-split-source {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+}
+
+.aegis-mdx-split-preview {
+  overflow: auto;
+  background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-tertiary));
+}
+
+.aegis-mdx-properties {
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-tertiary));
+  padding: 10px 14px 12px;
+}
+
+.aegis-mdx-properties-compact {
+  padding: 8px 12px;
+}
+
+.aegis-mdx-properties-header,
+.aegis-mdx-placeholder-main,
+.aegis-mdx-statusbar {
+  display: flex;
+  align-items: center;
+}
+
+.aegis-mdx-properties-header {
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.aegis-mdx-properties-title {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.aegis-mdx-properties-count {
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.aegis-mdx-properties-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px 10px;
+}
+
+.aegis-mdx-properties-compact .aegis-mdx-properties-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.aegis-mdx-property-row {
+  display: grid;
+  grid-template-columns: minmax(72px, 0.36fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 7px;
+  min-height: 28px;
+}
+
+.aegis-mdx-property-key {
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 11px;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.aegis-mdx-property-key:hover {
+  color: var(--text-primary);
+}
+
+.aegis-mdx-property-row input[type="text"],
+.aegis-mdx-property-row input[type="number"] {
+  min-width: 0;
+  width: 100%;
+  height: 25px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 5px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 12px;
+  outline: none;
+  padding: 0 8px;
+}
+
+.aegis-mdx-property-row input[type="text"]:focus,
+.aegis-mdx-property-row input[type="number"]:focus {
+  border-color: color-mix(in srgb, var(--accent) 56%, var(--border));
+}
+
+.aegis-mdx-property-row input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--accent);
+}
+
+.aegis-mdx-properties-warning,
+.aegis-mdx-properties-empty,
+.aegis-mdx-preview-empty {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.aegis-mdx-properties-warning {
+  width: 100%;
+  border: 1px solid color-mix(in srgb, var(--warning, #c77700) 42%, var(--border));
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--warning, #c77700) 9%, transparent);
+  color: color-mix(in srgb, var(--warning, #c77700) 84%, var(--text-primary));
+  padding: 7px 9px;
+  text-align: left;
+}
+
+.aegis-mdx-preview {
+  min-height: 100%;
+  background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-tertiary));
+}
+
+.project-markdown-preview.aegis-mdx-preview-body {
+  width: min(100%, 820px);
+  min-height: auto;
+  padding-top: 28px;
+}
+
+.aegis-mdx-markdown-chunk {
+  margin: 0;
+  padding: 0;
+}
+
+.aegis-mdx-markdown-chunk.markdown-content {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.aegis-mdx-placeholder {
+  margin: 1rem 0;
+  border: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-tertiary) 48%, var(--bg-primary));
+  padding: 11px 12px;
+}
+
+.aegis-mdx-placeholder-main {
+  gap: 8px;
+}
+
+.aegis-mdx-placeholder-badge {
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 650;
+  padding: 1px 7px;
+  text-transform: uppercase;
+}
+
+.aegis-mdx-placeholder-error .aegis-mdx-placeholder-badge {
+  border-color: color-mix(in srgb, var(--error) 50%, var(--border));
+  color: var(--error);
+}
+
+.aegis-mdx-placeholder-title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.aegis-mdx-placeholder-line {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.aegis-mdx-placeholder-detail {
+  margin-top: 7px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.aegis-mdx-placeholder code {
+  display: block;
+  margin-top: 8px;
+  overflow: auto;
+  border-radius: 5px;
+  background: var(--code-inline-bg);
+  color: var(--code-inline-text);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  padding: 7px 8px;
+  white-space: pre;
+}
+
+.aegis-mdx-placeholder-reveal {
+  margin-top: 8px;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+}
+
+.aegis-mdx-placeholder-reveal:hover {
+  color: var(--accent-hover);
+}
+
+.aegis-mdx-statusbar {
+  min-height: 27px;
+  gap: 12px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-tertiary));
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
+.aegis-mdx-statusbar .is-attention {
+  color: color-mix(in srgb, var(--warning, #c77700) 86%, var(--text-primary));
+}
+
+.aegis-mdx-statusbar .is-error {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--error);
+}
+
 .aegis-md-editor {
   --aegis-md-editor-surface: var(--workbench-surface, var(--bg-primary));
   --aegis-md-editor-chrome-surface: color-mix(in srgb, var(--aegis-md-editor-surface) 96%, var(--bg-primary));


### PR DESCRIPTION
## Summary
- keep `.mdx` files on the raw text editing path while preserving save support
- add an MDX source / preview / split experience with frontmatter Properties editing
- render draft MDX through a degraded preview with source reveal for unsupported JSX/components
- add CodeMirror line wrapping and source-line reveal support for MDX editing

## Why
The previous MDX path could flip files into a read-only preview state and rendered saved text instead of the live draft, so line breaks and unsaved edits were not reflected reliably.

## Validation
- `./node_modules/.bin/tsc -p src/electron/tsconfig.json`
- `/opt/homebrew/bin/node ./node_modules/.bin/vite build`
- `git diff --cached --check`
- `git diff --check -- src/ui/components/ProjectTreePanel.tsx src/ui/components/ProjectTextEditor.tsx src/ui/components/ProjectMdxPreview.tsx src/ui/index.css`