### PR TITLE
[codex] restore git header diff state

### DIFF
--- a/src/electron/ipc-handlers.ts
+++ b/src/electron/ipc-handlers.ts
@@ -101,7 +101,6 @@ import { register as registerPromptLibrary } from './ipc/prompt-library'
 import { register as registerMemory } from './ipc/memory'
 import { register as registerFont } from './ipc/font'
 import { register as registerSkillMarket } from './ipc/skill-market'
-import { register as registerGit } from './ipc/git'
 import {
   applyStash,
   checkoutBranch,
@@ -5203,7 +5202,6 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
   registerFont(ipcCtx)
   registerMemory(ipcCtx)
   registerSkillMarket(ipcCtx)
-  registerGit(ipcCtx)
 }
 
 // 处理客户端事件


### PR DESCRIPTION
## Summary

- Stop registering the split Git IPC module after the existing full Git IPC handlers are installed.
- Preserve the renderer contract for `get-git-overview`, `get-git-changes`, and related Git calls.

## Root Cause

`setupIPCHandlers` registered the full Git handlers first, then called `registerGit(ipcCtx)` from `src/electron/ipc/git.ts`. Because `ipcMainHandle` removes any existing handler before registering a new one, the split module overwrote the complete handlers with an older/incompatible implementation. The header then received a response shape that did not match what the UI expects, so repositories with changes could fail to show the Diff/Changes state.

## Validation

- `npm run transpile:electron`
- `npm run build`
- Confirmed `~/BubbleBrain` is a Git repository with local changes.
