### PR TITLE
[codex] restore workbench and markdown editor layout

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -302,7 +302,7 @@ export function App() {
   }, [connected]);
 
   const loadGitOverview = useCallback(async () => {
-    const cwd = (activeSession?.cwd || projectCwd || '').trim();
+    const cwd = (projectCwd || activeSession?.cwd || '').trim();
     if (!cwd) {
       setGitHeaderState({
         hasRepo: false,
@@ -655,18 +655,18 @@ export function App() {
           of the outer app row (preserves existing layout). */}
       <div className={rightPanelFullscreen ? 'hidden' : 'contents'}>
       {!showSettings && activeWorkspace === 'chat' && !sessionsLoaded ? (
-        <div className="aegis-workbench-frame aegis-workbench-frame--with-sidebar flex-1 min-w-0" />
+        <div className="flex-1 min-w-0 bg-[var(--bg-primary)]" />
       ) : showSettings ? (
-        <div className="aegis-workbench-frame flex-1 min-w-0 flex flex-col">
+        <div className="flex-1 min-w-0 flex flex-col bg-[var(--bg-primary)]">
           <div className="flex-1 min-h-0">
             <Settings />
           </div>
         </div>
       ) : activeWorkspace === 'skills' ? (
-        <div className="aegis-workbench-frame aegis-workbench-frame--with-sidebar flex-1 min-w-0 flex flex-col">
-          <div className={`${sidebarCollapsed ? 'h-9' : 'h-8'} aegis-workbench-drag-strip drag-region flex-shrink-0`}>
+        <div className="flex-1 min-w-0 flex flex-col bg-[var(--bg-primary)]">
+          <div className={`${sidebarCollapsed ? 'h-12' : 'h-8'} drag-region flex-shrink-0 bg-[var(--bg-primary)]`}>
             <div className="flex h-full items-center px-3">
-              {sidebarCollapsed ? <SidebarHeaderTrigger className="ml-[72px] -translate-y-[3px]" /> : null}
+              {sidebarCollapsed ? <SidebarHeaderTrigger className="ml-[72px]" /> : null}
             </div>
           </div>
           <main className="min-w-0 flex-1 overflow-y-auto">
@@ -676,19 +676,17 @@ export function App() {
           </main>
         </div>
       ) : activeWorkspace === 'prompts' ? (
-        <div className="aegis-workbench-frame aegis-workbench-frame--with-sidebar flex-1 min-w-0 min-h-0 flex overflow-hidden">
-          <PromptLibraryView />
-        </div>
+        <PromptLibraryView />
       ) : chatLayoutMode === 'split' || (activeSession && !showNewSession) ? (
         <div
-          className="aegis-workbench-frame aegis-workbench-frame--with-sidebar flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden transition-[padding] duration-200"
+          className="flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden transition-[padding] duration-200"
           style={{ paddingRight: 'var(--project-preview-space, 0px)' }}
         >
           {/* Top drag region */}
-          <div className={`${sidebarCollapsed ? 'h-9' : 'h-8'} aegis-workbench-drag-strip drag-region flex-shrink-0`}>
+          <div className={`${sidebarCollapsed ? 'h-12' : 'h-8'} drag-region flex-shrink-0 bg-[var(--bg-primary)]`}>
             <div className="flex h-full items-center justify-between px-3">
               <div className="flex items-center gap-0.5">
-                {sidebarCollapsed ? <SidebarHeaderTrigger className="ml-[72px] -translate-y-[3px]" /> : null}
+                {sidebarCollapsed ? <SidebarHeaderTrigger className="ml-[72px]" /> : null}
               </div>
               <div className="flex items-center justify-end">
                 <InlineProjectPanelHeaderActions
@@ -769,9 +767,7 @@ export function App() {
           </div>
         </div>
       ) : (
-        <div className="aegis-workbench-frame aegis-workbench-frame--with-sidebar flex-1 min-w-0 min-h-0 flex overflow-hidden">
-          <NewSessionView key={newSessionKey} />
-        </div>
+        <NewSessionView key={newSessionKey} />
       )}
       </div>
 

--- a/src/ui/components/ChatPane.tsx
+++ b/src/ui/components/ChatPane.tsx
@@ -944,10 +944,10 @@ export function ChatPane({
 
   return (
     <div
-      className={`relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden transition-colors ${
+      className={`relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[var(--bg-primary)] transition-colors ${
         isActive
-          ? 'bg-transparent'
-          : 'bg-[var(--workbench-surface-muted)]'
+          ? 'bg-[var(--bg-primary)]'
+          : 'bg-[color-mix(in_srgb,var(--bg-primary)_96%,var(--bg-secondary))]'
       }`}
       onMouseDown={() => {
         if (!isActive) {
@@ -978,7 +978,7 @@ export function ChatPane({
         </div>
       ) : (
         <>
-          <div className="flex h-9 items-center justify-between bg-transparent px-3">
+          <div className="flex h-9 items-center justify-between bg-[var(--bg-primary)] px-3">
             <div className="flex min-w-0 items-center gap-2 text-[12px] text-[var(--text-secondary)]">
               {directAgent ? (
                 <>
@@ -1017,7 +1017,7 @@ export function ChatPane({
               ) : null}
             </div>
           </div>
-          <div ref={scrollContainerRef} className="flex-1 overflow-auto p-5 relative">
+          <div ref={scrollContainerRef} className="flex-1 overflow-auto p-4 relative">
             {isActive ? <InSessionSearch /> : null}
 
             {session.readOnly && (
@@ -1231,7 +1231,7 @@ export function ChatPane({
           </div>
 
           {session.readOnly ? null : (
-            <div className="px-6 pb-5">
+            <div className="px-8 pb-4">
               {activePermissionRequest ? (
                 <PromptInput
                   sessionId={sessionId}

--- a/src/ui/components/NewSessionView.tsx
+++ b/src/ui/components/NewSessionView.tsx
@@ -472,10 +472,10 @@ export function NewSessionView() {
   };
 
   return (
-    <div className="flex-1 min-w-0 flex flex-col bg-transparent">
-      <div className={`${sidebarCollapsed ? 'h-9' : 'h-8'} aegis-workbench-drag-strip drag-region flex-shrink-0`}>
+    <div className="flex-1 min-w-0 flex flex-col">
+      <div className={`${sidebarCollapsed ? 'h-12' : 'h-8'} drag-region flex-shrink-0`}>
         <div className="flex h-full items-center px-3">
-          {sidebarCollapsed ? <SidebarHeaderTrigger className="ml-[72px] -translate-y-[3px]" /> : null}
+          {sidebarCollapsed ? <SidebarHeaderTrigger className="ml-[72px]" /> : null}
         </div>
       </div>
 
@@ -530,140 +530,140 @@ export function NewSessionView() {
             </div>
 
             <div className="mx-auto max-w-4xl">
-              <div className="relative">
-                {projectFileMentions.hasMentionQuery ? (
-                  <div className="absolute inset-x-0 bottom-full z-40">
-                    <ProjectFileMentionMenu
-                      suggestions={projectFileMentions.suggestions}
-                      selectedIndex={projectFileMentions.selectedIndex}
-                      loading={projectFileMentions.loading}
-                      onSelect={(suggestion) => {
-                        void handleSelectProjectFile(suggestion);
-                      }}
-                    />
-                  </div>
-                ) : capabilityMenu.hasSlashQuery ? (
-                  <div className="absolute inset-x-0 bottom-full z-40">
-                    <ClaudeSkillMenu
-                      suggestions={capabilityMenu.suggestions}
-                      selectedIndex={capabilityMenu.selectedIndex}
-                      empty={capabilityMenu.suggestions.length === 0}
-                      title={capabilityMenu.menuTitle}
-                      emptyMessage={capabilityMenu.emptyMessage}
-                      onSelect={(suggestion) => {
-                        capabilityMenu.selectSuggestion(suggestion);
-                        window.requestAnimationFrame(() => editorRef.current?.focus());
-                      }}
-                      onHighlight={capabilityMenu.setSelectedIndex}
-                    />
-                  </div>
-                ) : null}
-                <div className="aegis-composer-surface rounded-[26px]">
-                  {attachments.length > 0 && (
-                    <div className="px-5 pt-4">
-                      <AttachmentChips
-                        attachments={attachments}
-                        onRemove={(id) =>
-                          setAttachments((prev) => prev.filter((a) => a.id !== id))
-                        }
-                      />
-                    </div>
-                  )}
-
-                  <ComposerPromptEditor
-                    ref={editorRef}
-                    value={capabilityMenu.displayPrompt}
-                    cursorIndex={cursorIndex}
-                    slashContext={capabilityMenu.slashContext}
-                    agentMentionLabels={{}}
-                    onChange={(value, nextCursorIndex) => {
-                      void handlePromptChange(value, nextCursorIndex);
+              <div className="group relative rounded-[28px] bg-[var(--border)]/45 p-px transition-colors duration-200 focus-within:bg-[var(--border)]/70">
+              {projectFileMentions.hasMentionQuery ? (
+                <div className="absolute inset-x-0 bottom-full z-40">
+                  <ProjectFileMentionMenu
+                    suggestions={projectFileMentions.suggestions}
+                    selectedIndex={projectFileMentions.selectedIndex}
+                    loading={projectFileMentions.loading}
+                    onSelect={(suggestion) => {
+                      void handleSelectProjectFile(suggestion);
                     }}
-                    onPasteText={(context) => {
-                      return handleLongPaste(context);
-                    }}
-                    onPasteImages={(images) => {
-                      void handlePasteImages(images);
-                    }}
-                    onCompositionStart={() => {
-                      isComposingRef.current = true;
-                    }}
-                    onCompositionEnd={() => {
-                      isComposingRef.current = false;
-                    }}
-                    onKeyDown={handleKeyDown}
-                    placeholder={
-                      hasSelectedCwd
-                        ? 'Message the agent...'
-                        : 'Describe your task. Choose a project folder before it runs...'
-                    }
-                    className="w-full bg-transparent px-4 pt-3 pb-1 text-[14px] outline-none resize-none no-drag min-h-[56px] max-h-[200px]"
-                    autoFocus
                   />
-
-                  <div className="flex items-end justify-between gap-2 px-2.5 pb-2">
-                    <div className="flex min-w-0 flex-1 items-center gap-1 overflow-visible">
-                      {!hasSelectedCwd ? (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            void handleSelectProjectFolder();
-                          }}
-                          disabled={pendingStart}
-                          className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--bg-tertiary)] px-2.5 text-[12px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[color-mix(in_srgb,var(--bg-tertiary)_76%,var(--accent)_24%)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
-                          title="Choose project folder"
-                        >
-                          <FolderOpen className="h-3.5 w-3.5" />
-                          Choose project
-                        </button>
-                      ) : null}
-                      <ComposerAgentPicker
-                        value={agentSelection.provider}
-                        disabled={pendingStart}
-                        onChange={agentSelection.selectAgent}
-                      />
-                      <ComposerModelPicker
-                        value={agentSelection.model}
-                        selectedKey={agentSelection.selectedModelOption?.key ?? null}
-                        label={agentSelection.selectedModelLabel}
-                        options={agentSelection.modelOptions}
-                        setupLabel={agentSelection.modelSetup?.label}
-                        disabled={pendingStart}
-                        onSetup={openModelSetup}
-                        onChange={agentSelection.selectModel}
-                      />
-                      <SavePromptButton content={promptLibraryContent} disabled={pendingStart} />
-
-                      <button
-                        type="button"
-                        onClick={() => {
-                          void handleAddAttachments();
-                        }}
-                        disabled={pendingStart}
-                        className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--text-secondary)] transition-all duration-150 hover:bg-[var(--bg-tertiary)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
-                        title="Add files or photos"
-                        aria-label="Add files or photos"
-                      >
-                        <PlusIcon />
-                      </button>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                      <button
-                        onClick={handleStart}
-                        disabled={!canStartTask}
-                        className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--text-primary)] text-[var(--bg-primary)] transition-all duration-150 hover:scale-105 no-drag disabled:cursor-not-allowed disabled:opacity-20 disabled:hover:scale-100"
-                      >
-                        {pendingStart ? (
-                          <span className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                        ) : !hasSelectedCwd ? (
-                          <FolderOpen className="h-[18px] w-[18px]" />
-                        ) : (
-                          <ArrowUpIcon />
-                        )}
-                      </button>
-                    </div>
-                  </div>
                 </div>
+              ) : capabilityMenu.hasSlashQuery ? (
+                <div className="absolute inset-x-0 bottom-full z-40">
+                  <ClaudeSkillMenu
+                    suggestions={capabilityMenu.suggestions}
+                    selectedIndex={capabilityMenu.selectedIndex}
+                    empty={capabilityMenu.suggestions.length === 0}
+                    title={capabilityMenu.menuTitle}
+                    emptyMessage={capabilityMenu.emptyMessage}
+                    onSelect={(suggestion) => {
+                      capabilityMenu.selectSuggestion(suggestion);
+                      window.requestAnimationFrame(() => editorRef.current?.focus());
+                    }}
+                    onHighlight={capabilityMenu.setSelectedIndex}
+                  />
+                </div>
+              ) : null}
+              <div className="rounded-[26px] border border-[var(--border)]/65 bg-[var(--bg-primary)] transition-colors duration-200">
+              {attachments.length > 0 && (
+                <div className="px-5 pt-4">
+                  <AttachmentChips
+                    attachments={attachments}
+                    onRemove={(id) =>
+                      setAttachments((prev) => prev.filter((a) => a.id !== id))
+                    }
+                  />
+                </div>
+              )}
+
+              <ComposerPromptEditor
+                ref={editorRef}
+                value={capabilityMenu.displayPrompt}
+                cursorIndex={cursorIndex}
+                slashContext={capabilityMenu.slashContext}
+                agentMentionLabels={{}}
+                onChange={(value, nextCursorIndex) => {
+                  void handlePromptChange(value, nextCursorIndex);
+                }}
+                onPasteText={(context) => {
+                  return handleLongPaste(context);
+                }}
+                onPasteImages={(images) => {
+                  void handlePasteImages(images);
+                }}
+                onCompositionStart={() => {
+                  isComposingRef.current = true;
+                }}
+                onCompositionEnd={() => {
+                  isComposingRef.current = false;
+                }}
+                onKeyDown={handleKeyDown}
+                placeholder={
+                  hasSelectedCwd
+                    ? 'Message the agent...'
+                    : 'Describe your task. Choose a project folder before it runs...'
+                }
+                className="w-full bg-transparent px-4 pt-3 pb-1 text-[14px] outline-none resize-none no-drag min-h-[56px] max-h-[200px]"
+                autoFocus
+              />
+
+              <div className="flex items-end justify-between gap-2 px-2.5 pb-2">
+              <div className="flex min-w-0 flex-1 items-center gap-1 overflow-visible">
+              {!hasSelectedCwd ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    void handleSelectProjectFolder();
+                  }}
+                  disabled={pendingStart}
+                  className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--bg-tertiary)] px-2.5 text-[12px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[color-mix(in_srgb,var(--bg-tertiary)_76%,var(--accent)_24%)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+                  title="Choose project folder"
+                >
+                  <FolderOpen className="h-3.5 w-3.5" />
+                  Choose project
+                </button>
+              ) : null}
+              <ComposerAgentPicker
+                value={agentSelection.provider}
+                disabled={pendingStart}
+                onChange={agentSelection.selectAgent}
+              />
+              <ComposerModelPicker
+                value={agentSelection.model}
+                selectedKey={agentSelection.selectedModelOption?.key ?? null}
+                label={agentSelection.selectedModelLabel}
+                options={agentSelection.modelOptions}
+                setupLabel={agentSelection.modelSetup?.label}
+                disabled={pendingStart}
+                onSetup={openModelSetup}
+                onChange={agentSelection.selectModel}
+              />
+              <SavePromptButton content={promptLibraryContent} disabled={pendingStart} />
+
+              <button
+                type="button"
+                onClick={() => {
+                  void handleAddAttachments();
+                }}
+                disabled={pendingStart}
+                className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--text-secondary)] transition-all duration-150 hover:bg-[var(--bg-tertiary)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+                title="Add files or photos"
+                aria-label="Add files or photos"
+              >
+                <PlusIcon />
+              </button>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+              <button
+                onClick={handleStart}
+                disabled={!canStartTask}
+                className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--text-primary)] text-[var(--bg-primary)] transition-all duration-150 hover:scale-105 no-drag disabled:cursor-not-allowed disabled:opacity-20 disabled:hover:scale-100"
+              >
+                {pendingStart ? (
+                  <span className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                ) : !hasSelectedCwd ? (
+                  <FolderOpen className="h-[18px] w-[18px]" />
+                ) : (
+                  <ArrowUpIcon />
+                )}
+              </button>
+              </div>
+              </div>
+              </div>
               </div>
             </div>
 

--- a/src/ui/components/ProjectMarkdownEditor.tsx
+++ b/src/ui/components/ProjectMarkdownEditor.tsx
@@ -697,7 +697,7 @@ function ToolbarButton({
   return (
     <button
       type="button"
-      className={`aegis-md-toolbar-button${active ? ' active' : ''}`}
+      className={`aegis-md-toolbar-button no-drag${active ? ' active' : ''}`}
       title={title}
       aria-label={title}
       aria-pressed={active}
@@ -1051,7 +1051,7 @@ export function ProjectMarkdownEditor({
         </div>
       )}
 
-      <div className="aegis-md-toolbar" aria-label="Markdown formatting toolbar">
+      <div className="aegis-md-toolbar drag-region" aria-label="Markdown formatting toolbar">
         <div className="aegis-md-toolbar-tools">
         <ToolbarButton title="Undo" onClick={() => { viewRef.current && undo(viewRef.current.state, viewRef.current.dispatch); focusEditor(); }}>
           <Undo2 className="h-4 w-4" />

--- a/src/ui/components/ProjectMarkdownEditor.tsx
+++ b/src/ui/components/ProjectMarkdownEditor.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   Bold,
   CheckSquare,
+  ChevronDown,
+  ChevronUp,
   Code,
   Heading1,
   Heading2,
@@ -11,11 +13,13 @@ import {
   Link,
   List,
   ListOrdered,
+  Plus,
   Quote,
   Redo2,
   Strikethrough,
   Table,
   Undo2,
+  X,
 } from './icons';
 import {
   Editor,
@@ -71,12 +75,25 @@ type FrontmatterParts = {
   body: string;
 };
 
+type MarkdownMetadataFieldKind = 'array' | 'boolean' | 'number' | 'text';
+
+type MarkdownMetadataField = {
+  key: string;
+  value: string;
+  kind: MarkdownMetadataFieldKind;
+  items: string[];
+  arrayStyle: 'inline' | 'list' | null;
+  line: number;
+};
+
 type ProjectMarkdownEditorProps = {
   value: string;
   cwd: string;
   filePath: string;
   fileName: string;
   hideTitleBar?: boolean;
+  windowControlsInset?: boolean;
+  toolbarActions?: ReactNode;
   saveState: SaveState;
   saveError: string | null;
   externalChange: boolean;
@@ -91,6 +108,7 @@ const HEADING_FLASH_META = 'aegis-markdown-heading-flash';
 const OUTLINE_TARGET_MIN_TOP_OFFSET_PX = 72;
 const OUTLINE_TARGET_MAX_TOP_OFFSET_PX = 140;
 const OUTLINE_TARGET_VIEWPORT_RATIO = 0.16;
+const METADATA_VISIBLE_ROWS = 8;
 const MARKDOWN_IMAGE_MIME_TYPES = new Set([
   'image/png',
   'image/jpeg',
@@ -122,6 +140,268 @@ function combineFrontmatter(frontmatter: string, body: string): string {
   const normalizedBody = String(body || '').replace(/\r\n/g, '\n');
   if (!frontmatter) return normalizedBody;
   return `${frontmatter}${normalizedBody.replace(/^\n+/, '')}`;
+}
+
+function stripYamlQuote(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseYamlArrayItems(value: string): string[] {
+  return value
+    .replace(/^\[|\]$/g, '')
+    .split(',')
+    .map((item) => stripYamlQuote(item.trim()))
+    .filter(Boolean);
+}
+
+function formatYamlScalar(value: string, kind: MarkdownMetadataFieldKind = 'text'): string {
+  const trimmed = value.trim();
+  if (kind === 'boolean') return trimmed.toLowerCase() === 'true' ? 'true' : 'false';
+  if (kind === 'number' && /^-?\d+(?:\.\d+)?$/.test(trimmed)) return trimmed;
+  if (!trimmed) return '""';
+  if (/^(true|false|null|~|-?\d|\[|\{)/i.test(trimmed) || /[:#\n]/.test(trimmed)) {
+    return JSON.stringify(trimmed);
+  }
+  return trimmed;
+}
+
+function formatYamlInlineArray(items: string[]): string {
+  return `[${items.map((item) => JSON.stringify(item.trim())).join(', ')}]`;
+}
+
+function detectMetadataKind(value: string, items: string[]): MarkdownMetadataFieldKind {
+  const trimmed = value.trim();
+  if (items.length > 0 || /^\[[\s\S]*\]$/.test(trimmed)) return 'array';
+  if (/^(true|false)$/i.test(trimmed)) return 'boolean';
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return 'number';
+  return 'text';
+}
+
+function parseMarkdownMetadata(frontmatter: string): MarkdownMetadataField[] {
+  if (!frontmatter) return [];
+  const lines = frontmatter.replace(/\r\n/g, '\n').split('\n');
+  const fields: MarkdownMetadataField[] = [];
+  const closingIndex = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
+  const contentLines = lines[0]?.trim() === '---' && closingIndex > 0
+    ? lines.slice(1, closingIndex)
+    : lines;
+
+  contentLines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || /^\s/.test(line)) return;
+
+    const match = /^([A-Za-z0-9_.-]+):(?:\s*(.*))?$/.exec(line);
+    if (!match) return;
+
+    const rawValue = match[2] ?? '';
+    const listItems: string[] = [];
+    if (!rawValue.trim()) {
+      for (let nextIndex = index + 1; nextIndex < contentLines.length; nextIndex += 1) {
+        const listMatch = /^\s*-\s+(.+)$/.exec(contentLines[nextIndex]);
+        if (!listMatch) break;
+        listItems.push(stripYamlQuote(listMatch[1]));
+      }
+    }
+
+    const items = /^\[[\s\S]*\]$/.test(rawValue.trim())
+      ? parseYamlArrayItems(rawValue)
+      : listItems;
+    const kind = detectMetadataKind(rawValue, items);
+    const value = kind === 'array' ? items.join(', ') : stripYamlQuote(rawValue);
+
+    fields.push({
+      key: match[1],
+      value,
+      kind,
+      items,
+      arrayStyle: kind === 'array' ? (rawValue.trim() ? 'inline' : 'list') : null,
+      line: index + 2,
+    });
+  });
+
+  return fields;
+}
+
+function updateMarkdownMetadataValue(
+  frontmatter: string,
+  field: MarkdownMetadataField,
+  nextValue: string
+): string {
+  const lines = frontmatter.replace(/\r\n/g, '\n').split('\n');
+  const targetIndex = field.line - 1;
+  if (targetIndex <= 0 || targetIndex >= lines.length) return frontmatter;
+
+  const nextLines = [...lines];
+  nextLines[targetIndex] = `${field.key}: ${formatYamlScalar(nextValue, field.kind)}`;
+  return nextLines.join('\n');
+}
+
+function updateMarkdownMetadataArray(
+  frontmatter: string,
+  field: MarkdownMetadataField,
+  nextItems: string[]
+): string {
+  const lines = frontmatter.replace(/\r\n/g, '\n').split('\n');
+  const targetIndex = field.line - 1;
+  if (targetIndex <= 0 || targetIndex >= lines.length) return frontmatter;
+
+  const normalizedItems = nextItems.map((item) => item.trim()).filter(Boolean);
+  const closingIndex = lines.findIndex((line, index) => index > targetIndex && line.trim() === '---');
+  const blockEnd = closingIndex > targetIndex ? closingIndex : lines.length;
+  let removeTo = targetIndex + 1;
+  while (removeTo < blockEnd && /^\s*-\s+/.test(lines[removeTo])) {
+    removeTo += 1;
+  }
+
+  const nextLines = [...lines];
+  if (field.arrayStyle === 'list') {
+    nextLines.splice(
+      targetIndex,
+      removeTo - targetIndex,
+      `${field.key}:`,
+      ...normalizedItems.map((item) => `  - ${formatYamlScalar(item)}`)
+    );
+  } else {
+    nextLines.splice(
+      targetIndex,
+      removeTo - targetIndex,
+      `${field.key}: ${formatYamlInlineArray(normalizedItems)}`
+    );
+  }
+  return nextLines.join('\n');
+}
+
+function MarkdownMetadataCard({
+  fields,
+  expanded,
+  onToggleExpanded,
+  onUpdateValue,
+  onUpdateArray,
+}: {
+  fields: MarkdownMetadataField[];
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  onUpdateValue: (field: MarkdownMetadataField, value: string) => void;
+  onUpdateArray: (field: MarkdownMetadataField, items: string[]) => void;
+}) {
+  const [arrayDrafts, setArrayDrafts] = useState<Record<string, string>>({});
+  if (fields.length === 0) return null;
+
+  const visibleFields = expanded ? fields : fields.slice(0, METADATA_VISIBLE_ROWS);
+  const hasMore = fields.length > METADATA_VISIBLE_ROWS;
+
+  return (
+    <section className="aegis-mdx-metadata-card aegis-md-editor-metadata" aria-label="Metadata">
+      <div className="aegis-mdx-metadata-title">Metadata</div>
+      <div className="aegis-mdx-metadata-grid">
+        {visibleFields.map((field) => (
+          <div key={`${field.key}-${field.line}`} className="aegis-mdx-metadata-row">
+            <span className="aegis-mdx-metadata-key" title={field.key}>
+              {field.key}
+            </span>
+            {field.kind === 'array' ? (
+              <div className="aegis-mdx-metadata-chips" aria-label={field.key}>
+                {field.items.map((item, index) => (
+                  <span key={`${field.key}-${field.line}-${index}`} className="aegis-mdx-metadata-chip aegis-mdx-metadata-chip-editable">
+                    <input
+                      value={item}
+                      aria-label={`${field.key} ${index + 1}`}
+                      onChange={(event) => {
+                        const nextItems = [...field.items];
+                        nextItems[index] = event.target.value;
+                        onUpdateArray(field, nextItems);
+                      }}
+                    />
+                    <button
+                      type="button"
+                      className="aegis-mdx-metadata-chip-remove"
+                      aria-label={`Remove ${item}`}
+                      onClick={() => onUpdateArray(field, field.items.filter((_, itemIndex) => itemIndex !== index))}
+                    >
+                      <X className="h-3 w-3" aria-hidden="true" />
+                    </button>
+                  </span>
+                ))}
+                <span className="aegis-mdx-metadata-chip aegis-mdx-metadata-chip-add">
+                  <input
+                    value={arrayDrafts[`${field.key}-${field.line}`] || ''}
+                    placeholder="Add"
+                    aria-label={`Add ${field.key}`}
+                    onChange={(event) => {
+                      const draftKey = `${field.key}-${field.line}`;
+                      setArrayDrafts((current) => ({ ...current, [draftKey]: event.target.value }));
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== 'Enter') return;
+                      event.preventDefault();
+                      const draftKey = `${field.key}-${field.line}`;
+                      const nextItem = (arrayDrafts[draftKey] || '').trim();
+                      if (!nextItem) return;
+                      onUpdateArray(field, [...field.items, nextItem]);
+                      setArrayDrafts((current) => ({ ...current, [draftKey]: '' }));
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="aegis-mdx-metadata-chip-remove"
+                    aria-label={`Add ${field.key}`}
+                    onClick={() => {
+                      const draftKey = `${field.key}-${field.line}`;
+                      const nextItem = (arrayDrafts[draftKey] || '').trim();
+                      if (!nextItem) return;
+                      onUpdateArray(field, [...field.items, nextItem]);
+                      setArrayDrafts((current) => ({ ...current, [draftKey]: '' }));
+                    }}
+                  >
+                    <Plus className="h-3 w-3" aria-hidden="true" />
+                  </button>
+                </span>
+              </div>
+            ) : field.kind === 'boolean' ? (
+              <label className="aegis-mdx-metadata-boolean">
+                <input
+                  type="checkbox"
+                  checked={field.value.trim().toLowerCase() === 'true'}
+                  onChange={(event) => onUpdateValue(field, event.target.checked ? 'true' : 'false')}
+                />
+                <span>{field.value.trim().toLowerCase() === 'true' ? 'true' : 'false'}</span>
+              </label>
+            ) : (
+              <input
+                className={`aegis-mdx-metadata-input kind-${field.kind}`}
+                type="text"
+                inputMode={field.kind === 'number' ? 'decimal' : undefined}
+                value={field.value}
+                aria-label={field.key}
+                onChange={(event) => onUpdateValue(field, event.target.value)}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      {hasMore ? (
+        <button
+          type="button"
+          className="aegis-mdx-metadata-toggle"
+          onClick={onToggleExpanded}
+        >
+          {expanded ? 'Show less' : 'Show more'}
+          {expanded ? (
+            <ChevronUp className="h-4 w-4" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-4 w-4" aria-hidden="true" />
+          )}
+        </button>
+      ) : null}
+    </section>
+  );
 }
 
 function formatBreadcrumb(cwd: string, filePath: string): string {
@@ -438,6 +718,8 @@ export function ProjectMarkdownEditor({
   filePath,
   fileName,
   hideTitleBar = false,
+  windowControlsInset = false,
+  toolbarActions,
   saveState,
   saveError,
   externalChange,
@@ -459,7 +741,12 @@ export function ProjectMarkdownEditor({
   const [outlineOpen, setOutlineOpen] = useState(false);
   const [editorFocused, setEditorFocused] = useState(false);
   const [, forceToolbarState] = useState(0);
+  const [metadataExpanded, setMetadataExpanded] = useState(false);
   const breadcrumb = useMemo(() => formatBreadcrumb(cwd, filePath), [cwd, filePath]);
+  const metadataFields = useMemo(
+    () => parseMarkdownMetadata(splitFrontmatter(value).frontmatter),
+    [value]
+  );
 
   const runCommand = useCallback(<T,>(key: { id: string } | unknown, payload?: T) => {
     const editor = editorRef.current;
@@ -587,6 +874,22 @@ export function ProjectMarkdownEditor({
     focusEditor();
   }, [focusEditor, runCommand]);
 
+  const applyFrontmatterChange = useCallback((nextFrontmatter: string) => {
+    const currentParts = splitFrontmatter(currentFullMarkdownRef.current);
+    const next = combineFrontmatter(nextFrontmatter, currentParts.body);
+    frontmatterRef.current = nextFrontmatter;
+    currentFullMarkdownRef.current = next;
+    onChange(next);
+  }, [onChange]);
+
+  const updateMetadataValue = useCallback((field: MarkdownMetadataField, nextValue: string) => {
+    applyFrontmatterChange(updateMarkdownMetadataValue(frontmatterRef.current, field, nextValue));
+  }, [applyFrontmatterChange]);
+
+  const updateMetadataArray = useCallback((field: MarkdownMetadataField, nextItems: string[]) => {
+    applyFrontmatterChange(updateMarkdownMetadataArray(frontmatterRef.current, field, nextItems));
+  }, [applyFrontmatterChange]);
+
   useEffect(() => {
     const root = hostRef.current;
     if (!root) return;
@@ -708,6 +1011,10 @@ export function ProjectMarkdownEditor({
     };
   }, []);
 
+  useEffect(() => {
+    setMetadataExpanded(false);
+  }, [filePath]);
+
   const view = viewRef.current;
   const showActiveFormatting = editorFocused;
   const active = {
@@ -725,7 +1032,11 @@ export function ProjectMarkdownEditor({
   };
 
   return (
-    <div className={`aegis-md-editor${hideTitleBar ? ' title-hidden' : ''}`}>
+    <div
+      className={`aegis-md-editor${hideTitleBar ? ' title-hidden' : ''}${
+        windowControlsInset ? ' window-controls-inset' : ''
+      }`}
+    >
       {!hideTitleBar && (
         <div className="aegis-md-editor-top drag-region">
           <div className="aegis-md-title-cluster">
@@ -741,6 +1052,7 @@ export function ProjectMarkdownEditor({
       )}
 
       <div className="aegis-md-toolbar" aria-label="Markdown formatting toolbar">
+        <div className="aegis-md-toolbar-tools">
         <ToolbarButton title="Undo" onClick={() => { viewRef.current && undo(viewRef.current.state, viewRef.current.dispatch); focusEditor(); }}>
           <Undo2 className="h-4 w-4" />
         </ToolbarButton>
@@ -796,6 +1108,12 @@ export function ProjectMarkdownEditor({
         <ToolbarButton title="Image" onClick={() => void insertImage()}>
           <ImageIcon className="h-4 w-4" />
         </ToolbarButton>
+        </div>
+        {toolbarActions ? (
+          <div className="aegis-md-toolbar-actions no-drag">
+            {toolbarActions}
+          </div>
+        ) : null}
       </div>
 
       {externalChange && (
@@ -812,6 +1130,13 @@ export function ProjectMarkdownEditor({
 
       <div className="aegis-md-main">
         <div className="aegis-md-canvas">
+          <MarkdownMetadataCard
+            fields={metadataFields}
+            expanded={metadataExpanded}
+            onToggleExpanded={() => setMetadataExpanded((current) => !current)}
+            onUpdateValue={updateMetadataValue}
+            onUpdateArray={updateMetadataArray}
+          />
           <div
             ref={hostRef}
             className="aegis-md-milkdown-root"

--- a/src/ui/components/ProjectTreePanel.tsx
+++ b/src/ui/components/ProjectTreePanel.tsx
@@ -1871,22 +1871,22 @@ export function ProjectTreePanel({
       )}
 
       <div
-        className={`aegis-project-panel aegis-context-panel flex h-full flex-col font-sans transition-[width,opacity,transform,margin] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] ${
+        className={`aegis-project-panel relative flex h-full flex-col border-l border-[var(--tree-item-border)] bg-[var(--bg-primary)] font-sans transition-[width,opacity,transform,border-color] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] ${
           isFullscreen ? 'flex-1 min-w-0' : 'flex-shrink-0'
-        } ${selectedFilePath ? 'aegis-project-panel--preview-open' : ''} ${collapsed && !isFullscreen ? 'pointer-events-none' : ''}`}
+        } ${collapsed && !isFullscreen ? 'pointer-events-none' : ''}`}
         style={
           isFullscreen
             ? {
                 width: 'auto',
                 opacity: 1,
                 transform: 'translateX(0)',
-                marginLeft: 'var(--workbench-gap)',
+                borderLeftWidth: 1,
               }
             : {
                 width: collapsed ? 0 : panelWidth,
                 opacity: collapsed ? 0 : 1,
                 transform: collapsed ? 'translateX(18px)' : 'translateX(0)',
-                marginLeft: collapsed ? 0 : 'var(--workbench-gap)',
+                borderLeftWidth: collapsed ? 0 : 1,
               }
         }
         aria-hidden={collapsed && !isFullscreen}
@@ -1899,7 +1899,7 @@ export function ProjectTreePanel({
             <div className="absolute left-1/2 top-0 bottom-0 w-px -translate-x-1/2 bg-transparent group-hover:bg-[var(--border)]" />
           </div>
         )}
-        {!selectedFilePath && <div className="h-8 aegis-workbench-drag-strip drag-region flex-shrink-0" />}
+        {!selectedFilePath && <div className="h-8 drag-region flex-shrink-0 bg-[var(--bg-primary)]" />}
         <div className="pl-4 pr-2 pt-2 pb-2">
           <div className="flex items-center justify-between gap-2">
             <div
@@ -2198,7 +2198,7 @@ export function ProjectTreePanel({
 
         {selectedFilePath && (
           <div
-            className="aegis-project-preview-panel absolute inset-y-0 z-20"
+            className="absolute inset-y-0 z-20 border-l border-[var(--tree-item-border)] bg-[var(--bg-primary)] shadow-[-12px_0_32px_rgba(0,0,0,0.08)]"
             style={
               isFullscreen
                 ? { left: 0, right: 0, width: 'auto' }
@@ -2215,35 +2215,7 @@ export function ProjectTreePanel({
             )}
 
             <div className={`h-full min-w-0 flex flex-col ${isEditableMarkdownPreview ? '' : 'px-3 py-3'}`}>
-              {isEditableMarkdownPreview ? (
-                <div
-                  className={`flex h-10 flex-shrink-0 items-center justify-end gap-2 border-b border-[var(--border)]/60 bg-[var(--bg-primary)] px-4 ${
-                    isFullscreen ? 'drag-region' : 'no-drag'
-                  }`}
-                >
-                  <div className="flex items-center gap-2 no-drag">
-                    {onToggleFullscreen && (
-                      <IconButton
-                        onClick={onToggleFullscreen}
-                        tooltip={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen'}
-                        label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-                      >
-                        {isFullscreen ? (
-                          <Minimize2 className="w-4 h-4" />
-                        ) : (
-                          <Maximize2 className="w-4 h-4" />
-                        )}
-                      </IconButton>
-                    )}
-                    <IconButton
-                      onClick={closePreview}
-                      label="Close preview"
-                    >
-                      <X className="w-4 h-4" />
-                    </IconButton>
-                  </div>
-                </div>
-              ) : (
+              {!isEditableMarkdownPreview ? (
                 <div className="drag-region flex items-center justify-between gap-2 pb-2">
                   <div className="min-w-0">
                     <div className="text-xs text-[var(--text-muted)]">Preview</div>
@@ -2322,7 +2294,7 @@ export function ProjectTreePanel({
                     </IconButton>
                   </div>
                 </div>
-              )}
+              ) : null}
 
               <div
                 className={`flex-1 min-h-0 overflow-auto ${
@@ -2392,9 +2364,33 @@ export function ProjectTreePanel({
                       filePath={selectedFilePath}
                       fileName={selectedPreview.name}
                       hideTitleBar
+                      windowControlsInset={isFullscreen}
                       saveState={saveState}
                       saveError={saveError}
                       externalChange={externalDiskText !== null}
+                      toolbarActions={
+                        <>
+                          {onToggleFullscreen && (
+                            <IconButton
+                              onClick={onToggleFullscreen}
+                              tooltip={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen'}
+                              label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+                            >
+                              {isFullscreen ? (
+                                <Minimize2 className="w-4 h-4" />
+                              ) : (
+                                <Maximize2 className="w-4 h-4" />
+                              )}
+                            </IconButton>
+                          )}
+                          <IconButton
+                            onClick={closePreview}
+                            label="Close preview"
+                          >
+                            <X className="w-4 h-4" />
+                          </IconButton>
+                        </>
+                      }
                       onChange={setDraftText}
                       onSave={handleSaveText}
                       onReloadExternal={handleReloadMarkdownExternal}

--- a/src/ui/components/PromptInput.tsx
+++ b/src/ui/components/PromptInput.tsx
@@ -558,7 +558,7 @@ export function PromptInput({
           {approvalPending && approvalPanel ? (
             approvalPanel
           ) : (
-          <div className="aegis-composer-surface rounded-[26px]">
+          <div className="rounded-[26px] border border-[color-mix(in_srgb,var(--border)_72%,transparent)] bg-[var(--bg-primary)] shadow-[0_18px_44px_rgba(15,23,42,0.08)] transition-[border-color,box-shadow] duration-200 focus-within:border-[color-mix(in_srgb,var(--border)_92%,transparent)] focus-within:shadow-[0_20px_52px_rgba(15,23,42,0.12)]">
           {attachments.length > 0 && (
             <div className="px-5 pt-4">
               <AttachmentChips

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -380,7 +380,7 @@ export function Sidebar() {
           style={{ width: sidebarCollapsed ? 0 : sidebarWidth }}
         >
           <div
-            className={`aegis-sidebar-surface relative flex h-full min-h-0 flex-col overflow-hidden transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] ${
+            className={`relative flex h-full min-h-0 flex-col overflow-hidden border-r border-[var(--border)] bg-[var(--app-sidebar-surface)] transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] ${
                 sidebarCollapsed
                   ? 'pointer-events-none -translate-x-2 opacity-0'
                   : 'translate-x-0 opacity-100'
@@ -388,10 +388,9 @@ export function Sidebar() {
             style={{ width: sidebarWidth, minWidth: sidebarWidth }}
             aria-hidden={sidebarCollapsed}
           >
-            <div className="drag-region flex h-9 flex-shrink-0 items-center gap-0.5 pl-[84px] pr-2">
+            <div className="drag-region flex h-12 flex-shrink-0 items-center gap-0.5 pl-[84px] pr-2">
               <SidebarToggleButton
                 collapsed={sidebarCollapsed}
-                className="-translate-y-[3px]"
                 onClick={toggleSidebarCollapsed}
               />
             </div>

--- a/src/ui/components/browser/BrowserPanel.tsx
+++ b/src/ui/components/browser/BrowserPanel.tsx
@@ -544,7 +544,7 @@ export function BrowserPanel({
   // ===== Render =====
   return (
     <div
-      className={`aegis-context-panel flex h-full flex-col transition-[width,opacity,transform,margin] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] ${
+      className={`relative flex h-full flex-col border-l border-[var(--border)] bg-[var(--bg-primary)] transition-[width,opacity,transform,border-color] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] ${
         isFullscreen ? 'flex-1 min-w-0' : 'flex-shrink-0'
       } ${collapsed && !isFullscreen ? 'pointer-events-none' : ''}`}
       style={
@@ -553,13 +553,13 @@ export function BrowserPanel({
               width: 'auto',
               opacity: 1,
               transform: 'translateX(0)',
-              marginLeft: 'var(--workbench-gap)',
+              borderLeftWidth: 1,
             }
           : {
               width: collapsed ? 0 : width,
               opacity: collapsed ? 0 : 1,
               transform: collapsed ? 'translateX(18px)' : 'translateX(0)',
-              marginLeft: collapsed ? 0 : 'var(--workbench-gap)',
+              borderLeftWidth: collapsed ? 0 : 1,
             }
       }
       aria-hidden={collapsed && !isFullscreen}
@@ -574,7 +574,7 @@ export function BrowserPanel({
       )}
 
       {/* Top drag strip */}
-      <div className="h-8 aegis-workbench-drag-strip drag-region flex-shrink-0" />
+      <div className="h-8 drag-region flex-shrink-0" />
 
       {/* Chrome */}
       <div className="no-drag flex-shrink-0 bg-[var(--bg-secondary)]/45">

--- a/src/ui/components/prompts/PromptLibraryView.tsx
+++ b/src/ui/components/prompts/PromptLibraryView.tsx
@@ -215,10 +215,10 @@ export function PromptLibraryView() {
   const hasFilters = Boolean(searchQuery.trim()) || selectedCategory !== 'all';
 
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col bg-transparent">
-      <div className={`${sidebarCollapsed ? 'h-9' : 'h-8'} aegis-workbench-drag-strip drag-region flex-shrink-0`}>
+    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col bg-[color:color-mix(in_srgb,var(--bg-primary)_92%,var(--bg-tertiary))]">
+      <div className={`${sidebarCollapsed ? 'h-12' : 'h-8'} drag-region flex-shrink-0 bg-transparent`}>
         <div className="flex h-full items-center px-3">
-          {sidebarCollapsed ? <SidebarHeaderTrigger className="ml-[72px] -translate-y-[3px]" /> : null}
+          {sidebarCollapsed ? <SidebarHeaderTrigger className="ml-[72px]" /> : null}
         </div>
       </div>
 

--- a/src/ui/components/settings/Settings.tsx
+++ b/src/ui/components/settings/Settings.tsx
@@ -85,14 +85,14 @@ export function Settings() {
     : 'general';
   const activeMeta = SETTINGS_TABS[resolvedActiveSettingsTab];
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col bg-transparent">
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-[var(--bg-primary)]">
       <div className="flex h-8 flex-shrink-0">
-        <div className="aegis-window-left-surface drag-region w-[280px] flex-shrink-0 bg-[var(--workbench-surface-muted)]" />
-        <div className="drag-region flex-1 bg-transparent" />
+        <div className="aegis-window-left-surface drag-region w-[280px] flex-shrink-0 border-r border-[var(--border)] bg-[var(--app-sidebar-surface)]" />
+        <div className="drag-region flex-1 bg-[var(--bg-primary)]" />
       </div>
 
-      <div className="flex min-h-0 flex-1 bg-transparent">
-      <aside className="aegis-window-left-surface w-[280px] flex-shrink-0 select-none bg-[var(--workbench-surface-muted)]">
+      <div className="flex min-h-0 flex-1 bg-[var(--bg-primary)]">
+      <aside className="aegis-window-left-surface w-[280px] flex-shrink-0 select-none border-r border-[var(--border)] bg-[var(--app-sidebar-surface)]">
         <div className="flex h-full flex-col px-3 pb-6 pt-4">
           <button
             onClick={() => setShowSettings(false)}
@@ -102,7 +102,7 @@ export function Settings() {
             <span>Back</span>
           </button>
 
-          <div className="mb-3 h-px bg-[var(--panel-soft-divider)]" />
+          <div className="mb-3 border-b border-[var(--border)]" />
 
           <div className="mb-2 px-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
             Settings
@@ -123,7 +123,7 @@ export function Settings() {
         </div>
       </aside>
 
-      <main className="min-w-0 flex-1 overflow-y-auto bg-transparent">
+      <main className="min-w-0 flex-1 overflow-y-auto bg-[var(--bg-primary)]">
         <div
           className="mx-auto max-w-3xl px-10 py-8"
         >

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -88,39 +88,8 @@
   --sidebar-segment-bg: #E0E2E5;
   --sidebar-segment-active: #F3F4F6;
   --sidebar-segment-shadow-active: 0 1px 3px rgba(20, 20, 20, 0.08);
-  --app-canvas: #ececef;
-  --app-sidebar-surface: #dedee1;
-  --app-sidebar-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.52),
-    inset -1px 0 0 rgba(17, 24, 39, 0.025);
-  --workbench-surface: #fcfcfd;
-  --workbench-surface-muted: rgba(17, 24, 39, 0.035);
-  --workbench-radius: 22px;
-  --workbench-outer-padding: 8px;
-  --workbench-gap: 10px;
-  --workbench-inset-shadow:
-    inset 0 0 0 1px rgba(17, 24, 39, 0.045),
-    inset 0 1px 0 rgba(255, 255, 255, 0.86);
-  --workbench-shadow:
-    0 1px 1px rgba(17, 24, 39, 0.025),
-    0 18px 50px -38px rgba(17, 24, 39, 0.58),
-    0 10px 26px -24px rgba(17, 24, 39, 0.42);
-  --context-panel-surface: #f8f8fa;
-  --context-panel-radius: 18px;
-  --context-panel-shadow:
-    inset 0 0 0 1px rgba(17, 24, 39, 0.045),
-    inset 0 1px 0 rgba(255, 255, 255, 0.72),
-    0 14px 42px -34px rgba(17, 24, 39, 0.5);
+  --app-sidebar-surface: #dcdcddff;
   --panel-soft-divider: rgba(17, 24, 39, 0.075);
-  --composer-surface: #ffffff;
-  --composer-border: rgba(17, 24, 39, 0.07);
-  --composer-border-focus: rgba(17, 24, 39, 0.13);
-  --composer-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.82),
-    0 16px 44px -34px rgba(17, 24, 39, 0.58);
-  --composer-shadow-focus:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.9),
-    0 18px 52px -32px rgba(17, 24, 39, 0.62);
   --border-focus: rgba(79, 70, 229, 0.45);
 
   /* Radius system */
@@ -219,35 +188,7 @@
   --sidebar-segment-bg: #30343B;
   --sidebar-segment-active: #454B55;
   --sidebar-segment-shadow-active: 0 1px 3px rgba(0, 0, 0, 0.24);
-  --app-canvas: #0b0c0e;
-  --app-sidebar-surface: #111214;
-  --app-sidebar-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.035),
-    inset -1px 0 0 rgba(255, 255, 255, 0.025);
-  --workbench-surface: #151619;
-  --workbench-surface-muted: rgba(255, 255, 255, 0.035);
-  --workbench-inset-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.055),
-    inset 0 1px 0 rgba(255, 255, 255, 0.045);
-  --workbench-shadow:
-    0 1px 1px rgba(0, 0, 0, 0.22),
-    0 22px 60px -38px rgba(0, 0, 0, 0.78),
-    0 10px 28px -24px rgba(0, 0, 0, 0.68);
-  --context-panel-surface: #131417;
-  --context-panel-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.055),
-    inset 0 1px 0 rgba(255, 255, 255, 0.035),
-    0 18px 52px -36px rgba(0, 0, 0, 0.78);
   --panel-soft-divider: rgba(255, 255, 255, 0.075);
-  --composer-surface: #191a1e;
-  --composer-border: rgba(255, 255, 255, 0.075);
-  --composer-border-focus: rgba(255, 255, 255, 0.15);
-  --composer-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.035),
-    0 18px 48px -34px rgba(0, 0, 0, 0.74);
-  --composer-shadow-focus:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.055),
-    0 20px 56px -32px rgba(0, 0, 0, 0.82);
   --border-focus: rgba(129, 140, 248, 0.5);
 
   /* Popover / dropdown surface (unified) */
@@ -305,117 +246,30 @@ body,
 
 html {
   font-size: 100%;
-  background-color: var(--app-canvas, var(--bg-primary));
+  background-color: var(--bg-primary);
 }
 
 body {
   font-family: var(--font-sans), 'IBM Plex Serif Var', 'IBM Plex Serif', ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
   font-size: 13px;
   line-height: 1.5;
-  background-color: var(--app-shell-background, var(--app-canvas, var(--bg-primary)));
+  background-color: var(--app-shell-background, var(--bg-primary));
   color: var(--text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 #root {
-  background-color: var(--app-canvas, var(--bg-primary));
+  background-color: var(--bg-primary);
 }
 
 .aegis-window-shell {
-  background:
-    radial-gradient(circle at 42% -18%, rgba(255, 255, 255, 0.5), transparent 34%),
-    var(--app-shell-background, var(--app-canvas, var(--bg-primary)));
-  padding: var(--workbench-outer-padding);
-  overflow: hidden;
+  background-color: var(--bg-primary);
 }
 
-.aegis-sidebar {
-  background: transparent;
-}
-
-.dark .aegis-window-shell {
-  background:
-    radial-gradient(circle at 42% -18%, rgba(255, 255, 255, 0.055), transparent 34%),
-    var(--app-shell-background, var(--app-canvas, var(--bg-primary)));
-}
-
-.aegis-sidebar-surface {
+.aegis-window-shell--rounded .aegis-sidebar,
+.aegis-window-shell--rounded .aegis-window-left-surface {
   background-color: var(--app-sidebar-surface);
-  border-radius: calc(var(--workbench-radius) - 4px);
-  box-shadow: var(--app-sidebar-shadow);
-}
-
-.aegis-workbench-frame {
-  position: relative;
-  min-width: 0;
-  min-height: 0;
-  isolation: isolate;
-  overflow: hidden;
-  border-radius: var(--workbench-radius);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.52), transparent 42px),
-    var(--workbench-surface);
-  box-shadow:
-    var(--workbench-inset-shadow),
-    var(--workbench-shadow);
-}
-
-.dark .aegis-workbench-frame {
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent 42px),
-    var(--workbench-surface);
-}
-
-.aegis-workbench-frame--with-sidebar {
-  margin-left: var(--workbench-gap);
-}
-
-.aegis-workbench-drag-strip {
-  background: transparent;
-}
-
-.aegis-context-panel {
-  position: relative;
-  isolation: isolate;
-  overflow: hidden;
-  border-radius: var(--context-panel-radius);
-  background: var(--context-panel-surface);
-  box-shadow: var(--context-panel-shadow);
-}
-
-.aegis-project-panel--preview-open.aegis-context-panel {
-  overflow: visible;
-}
-
-.aegis-project-preview-panel {
-  overflow: hidden;
-  border-radius: var(--context-panel-radius);
-  background: var(--context-panel-surface);
-  box-shadow: var(--context-panel-shadow);
-}
-
-.aegis-composer-surface {
-  border: 1px solid var(--composer-border);
-  background: var(--composer-surface);
-  box-shadow: var(--composer-shadow);
-  transition:
-    border-color 180ms ease,
-    box-shadow 180ms ease;
-}
-
-.aegis-composer-surface:focus-within {
-  border-color: var(--composer-border-focus);
-  box-shadow: var(--composer-shadow-focus);
-}
-
-@media (max-width: 900px) {
-  :root {
-    --workbench-outer-padding: 6px;
-    --workbench-gap: 6px;
-    --workbench-radius: 18px;
-    --context-panel-radius: 16px;
-  }
 }
 
 .aegis-sidebar,
@@ -1483,8 +1337,209 @@ button.md-inline-file-code:hover {
   padding: 10px 14px 12px;
 }
 
+.aegis-mdx-metadata-card {
+  box-sizing: border-box;
+  width: min(100%, 820px);
+  margin: 32px auto 0;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--bg-tertiary) 58%, var(--bg-primary));
+  padding: 18px 26px 20px;
+}
+
 .aegis-mdx-properties-compact {
   padding: 8px 12px;
+}
+
+.aegis-mdx-metadata-title {
+  margin-bottom: 16px;
+  color: var(--text-muted);
+  font-size: 16px;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+.aegis-mdx-metadata-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.aegis-mdx-metadata-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.36fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.aegis-mdx-metadata-key {
+  min-width: 0;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: default;
+  font-family: var(--font-mono);
+  font-size: 15px;
+  line-height: 1.45;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+button.aegis-mdx-metadata-key {
+  cursor: pointer;
+}
+
+button.aegis-mdx-metadata-key:hover {
+  color: var(--text-primary);
+}
+
+.aegis-mdx-metadata-value {
+  min-width: 0;
+  color: color-mix(in srgb, var(--text-primary) 90%, #333);
+  font-size: 15px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.aegis-mdx-metadata-value.kind-boolean,
+.aegis-mdx-metadata-value.kind-number {
+  font-family: var(--font-mono);
+}
+
+.aegis-mdx-metadata-input {
+  min-width: 0;
+  width: 100%;
+  height: 27px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: color-mix(in srgb, var(--text-primary) 90%, #333);
+  font-size: 15px;
+  line-height: 1.45;
+  outline: none;
+  padding: 0 7px;
+}
+
+.aegis-mdx-metadata-input.kind-number {
+  font-family: var(--font-mono);
+}
+
+.aegis-mdx-metadata-input:hover,
+.aegis-mdx-metadata-input:focus {
+  border-color: color-mix(in srgb, var(--border) 72%, transparent);
+  background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
+}
+
+.aegis-mdx-metadata-boolean {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 9px;
+  color: color-mix(in srgb, var(--text-primary) 90%, #333);
+  font-family: var(--font-mono);
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.aegis-mdx-metadata-boolean input {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--accent);
+}
+
+.aegis-mdx-metadata-chips {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 7px 8px;
+}
+
+.aegis-mdx-metadata-chip {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: center;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted) 16%, transparent);
+  color: color-mix(in srgb, var(--text-primary) 88%, #333);
+  font-size: 14px;
+  line-height: 1.2;
+  padding: 4px 10px;
+}
+
+.aegis-mdx-metadata-chip-editable,
+.aegis-mdx-metadata-chip-add {
+  gap: 5px;
+  padding: 3px 5px 3px 9px;
+}
+
+.aegis-mdx-metadata-chip input {
+  min-width: 36px;
+  width: min(18ch, 100%);
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: 1.2;
+  padding: 0;
+}
+
+.aegis-mdx-metadata-chip input::placeholder {
+  color: var(--text-muted);
+}
+
+.aegis-mdx-metadata-chip-remove {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: color-mix(in srgb, var(--text-muted) 90%, var(--text-primary));
+}
+
+.aegis-mdx-metadata-chip-remove:hover {
+  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
+  color: var(--text-primary);
+}
+
+.aegis-mdx-metadata-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1.25;
+  padding: 0;
+}
+
+.aegis-mdx-metadata-toggle:hover {
+  color: var(--text-primary);
+}
+
+.aegis-mdx-metadata-toggle svg {
+  flex: 0 0 auto;
+}
+
+.aegis-md-editor-metadata {
+  width: clamp(
+    0px,
+    calc(100% - (var(--aegis-md-page-padding-x) * 2)),
+    var(--aegis-md-body-width)
+  );
+}
+
+.aegis-md-editor-metadata + .aegis-md-milkdown-root {
+  padding-top: 28px;
 }
 
 .aegis-mdx-properties-header,
@@ -1708,6 +1763,9 @@ button.md-inline-file-code:hover {
 .aegis-md-editor {
   --aegis-md-editor-surface: var(--workbench-surface, var(--bg-primary));
   --aegis-md-editor-chrome-surface: color-mix(in srgb, var(--aegis-md-editor-surface) 96%, var(--bg-primary));
+  --aegis-md-page-width: 780px;
+  --aegis-md-page-padding-x: 34px;
+  --aegis-md-body-width: calc(var(--aegis-md-page-width) - (var(--aegis-md-page-padding-x) * 2));
   display: flex;
   min-height: 100%;
   height: 100%;
@@ -1787,13 +1845,36 @@ button.md-inline-file-code:hover {
 .aegis-md-toolbar {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   min-height: 42px;
   padding: 5px 12px;
   border-top: 1px solid color-mix(in srgb, var(--border) 48%, transparent);
   border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   background: var(--aegis-md-editor-chrome-surface);
+  overflow: hidden;
+}
+
+.aegis-md-editor.window-controls-inset .aegis-md-toolbar {
+  padding-left: 104px;
+}
+
+.aegis-md-toolbar-tools {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 4px;
   overflow-x: auto;
+}
+
+.aegis-md-toolbar-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  padding-left: 8px;
+  border-left: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
 }
 
 .aegis-md-toolbar-button {
@@ -1874,10 +1955,10 @@ button.md-inline-file-code:hover {
 
 .aegis-md-milkdown-root {
   box-sizing: border-box;
-  width: min(100%, 780px);
+  width: min(100%, var(--aegis-md-page-width));
   min-height: 100%;
   margin: 0 auto;
-  padding: 30px 34px 120px;
+  padding: 30px var(--aegis-md-page-padding-x) 120px;
 }
 
 .aegis-md-milkdown-root .ProseMirror {

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -2002,7 +2002,7 @@ button.aegis-mdx-metadata-key:hover {
 }
 
 .aegis-md-milkdown-root .ProseMirror p {
-  margin: 0.55rem 0;
+  margin: 0.72em 0;
 }
 
 .aegis-md-milkdown-root .ProseMirror blockquote {

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -2002,7 +2002,7 @@ button.aegis-mdx-metadata-key:hover {
 }
 
 .aegis-md-milkdown-root .ProseMirror p {
-  margin: 0.72em 0;
+  margin: 1em 0;
 }
 
 .aegis-md-milkdown-root .ProseMirror blockquote {


### PR DESCRIPTION
## Summary

- Restore the embedded three-column workbench layout instead of the floating workbench frame treatment.
- Collapse the Markdown editor fullscreen/close controls into the formatting toolbar row.
- Add a fullscreen-only toolbar inset so Markdown controls do not overlap macOS traffic lights.
- Align the Markdown metadata/front matter card with the editor body width.

## Validation

- `git diff --cached --check`
- `npm run build`

Note: this PR intentionally excludes unrelated local changes currently present in the working tree, including README formatting, Bubble local settings, terminal/WebGL work, MDX preview edits, theme edits, and `color-schemes.html`.