### PR TITLE
[codex] enable markdown toolbar window drag

### DIFF
--- a/src/ui/components/ProjectMarkdownEditor.tsx
+++ b/src/ui/components/ProjectMarkdownEditor.tsx
@@ -697,7 +697,7 @@ function ToolbarButton({
   return (
     <button
       type="button"
-      className={`aegis-md-toolbar-button${active ? ' active' : ''}`}
+      className={`aegis-md-toolbar-button no-drag${active ? ' active' : ''}`}
       title={title}
       aria-label={title}
       aria-pressed={active}
@@ -1051,7 +1051,7 @@ export function ProjectMarkdownEditor({
         </div>
       )}
 
-      <div className="aegis-md-toolbar" aria-label="Markdown formatting toolbar">
+      <div className="aegis-md-toolbar drag-region" aria-label="Markdown formatting toolbar">
         <div className="aegis-md-toolbar-tools">
         <ToolbarButton title="Undo" onClick={() => { viewRef.current && undo(viewRef.current.state, viewRef.current.dispatch); focusEditor(); }}>
           <Undo2 className="h-4 w-4" />


### PR DESCRIPTION
## Summary

- Make the Markdown editor toolbar a window drag region when the editor title bar is hidden.
- Mark toolbar formatting buttons as `no-drag` so button clicks still work normally.

## Root Cause

The project preview path renders `ProjectMarkdownEditor` with `hideTitleBar`, which removes the original `.aegis-md-editor-top.drag-region`. The visible toolbar was not marked as a drag region, so dragging from the Markdown editor header area had no effect.

## Validation

- `git diff --cached --check`
- `npm run build`

This PR is stacked on #7 (`codex/restore-workbench-markdown-editor`) so the diff stays focused on the toolbar drag fix.