### PR TITLE
[codex] persist markdown edits on quit

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Your Name",
   "main": "dist-electron/electron/main.js",
   "scripts": {
-    "dev": "concurrently \"npm run dev:react\" \"npm run dev:electron\"",
+    "dev": "concurrently --kill-others-on-fail \"npm run dev:react\" \"npm run dev:electron\"",
     "dev:react": "node scripts/dev-react.mjs",
     "dev:electron": "npm run transpile:electron && node scripts/prepare-electron-native-deps.mjs && node scripts/launch-electron.mjs",
     "transpile:electron": "tsc -p src/electron/tsconfig.json",

--- a/src/electron/ipc-handlers.ts
+++ b/src/electron/ipc-handlers.ts
@@ -235,6 +235,50 @@ async function waitForPathToDisappear(filePath: string): Promise<boolean> {
   return false;
 }
 
+const projectFileWatchers = new Map<
+  string,
+  { watcher: FSWatcher; timer?: NodeJS.Timeout; cwd: string; filePath: string; base: string }
+>();
+
+function projectFileWatchKey(cwd: string, filePath: string): string {
+  return `${resolve(cwd || '.')}\u0000${resolve(cwd || '.', filePath || '')}`;
+}
+
+function closeProjectFileWatcher(key: string): void {
+  const entry = projectFileWatchers.get(key);
+  if (!entry) return;
+  if (entry.timer) {
+    clearTimeout(entry.timer);
+  }
+  try {
+    entry.watcher.close();
+  } catch {
+    // watcher may already be closed
+  }
+  projectFileWatchers.delete(key);
+}
+
+async function writeTextFileAtomic(filePath: string, content: string, mode: number): Promise<void> {
+  const tempPath = join(
+    dirname(filePath),
+    `.${basename(filePath)}.${process.pid}.${Date.now()}.${Math.random()
+      .toString(36)
+      .slice(2)}.tmp`
+  );
+
+  try {
+    await fsPromises.writeFile(tempPath, content, { encoding: 'utf8', mode });
+    await fsPromises.rename(tempPath, filePath);
+  } catch (error) {
+    try {
+      await fsPromises.unlink(tempPath);
+    } catch {
+      // ignore cleanup failures
+    }
+    throw error;
+  }
+}
+
 async function isReadableDirectory(path: string): Promise<boolean> {
   try {
     const stat = await fsPromises.stat(path);
@@ -547,6 +591,7 @@ type ProjectFilePreview =
       name: string;
       ext: string;
       size: number;
+      mtimeMs: number;
       text: string;
       editable: boolean;
     }
@@ -3213,6 +3258,39 @@ function scheduleProjectTree(mainWindow: BrowserWindow, cwd: string): void {
   }, PROJECT_TREE_REFRESH_DELAY_MS);
 }
 
+async function emitProjectFile(
+  mainWindow: BrowserWindow,
+  cwd: string,
+  filePath: string
+): Promise<void> {
+  const resolved = resolve(cwd || '.', filePath || '');
+  try {
+    const stat = await fsPromises.stat(resolved);
+    if (!stat.isFile()) return;
+    const text = await fsPromises.readFile(resolved, 'utf8');
+    broadcast(mainWindow, {
+      type: 'project.file',
+      payload: { cwd, filePath, text, mtimeMs: stat.mtimeMs, size: stat.size, exists: true },
+    });
+  } catch {
+    broadcast(mainWindow, {
+      type: 'project.file',
+      payload: { cwd, filePath, text: '', mtimeMs: 0, size: 0, exists: false },
+    });
+  }
+}
+
+function scheduleProjectFile(mainWindow: BrowserWindow, key: string): void {
+  const entry = projectFileWatchers.get(key);
+  if (!entry) return;
+  if (entry.timer) {
+    clearTimeout(entry.timer);
+  }
+  entry.timer = setTimeout(() => {
+    emitProjectFile(mainWindow, entry.cwd, entry.filePath);
+  }, 150);
+}
+
 function mapGitChangeStatus(indexStatus: string, workStatus: string): {
   status: 'M' | 'A' | 'D' | 'R' | '?';
   staged: boolean;
@@ -4353,6 +4431,7 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
             name,
             ext,
             size: stat.size,
+            mtimeMs: stat.mtimeMs,
             text,
             editable: ext === '.txt' || ext === '.md' || ext === '.mdx',
           };
@@ -4406,7 +4485,7 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
       cwd: string,
       filePath: string,
       content: string
-    ): Promise<{ ok: true } | { ok: false; message: string }> => {
+    ): Promise<{ ok: true; size: number; mtimeMs: number } | { ok: false; message: string }> => {
       const resolved = resolve(cwd || '.', filePath || '');
       const ext = extname(resolved).toLowerCase();
 
@@ -4436,8 +4515,9 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
       }
 
       try {
-        await fsPromises.writeFile(validation.targetReal, content ?? '', 'utf8');
-        return { ok: true };
+        await writeTextFileAtomic(validation.targetReal, content ?? '', stat.mode);
+        const savedStat = await fsPromises.stat(validation.targetReal);
+        return { ok: true, size: savedStat.size, mtimeMs: savedStat.mtimeMs };
       } catch (error) {
         return { ok: false, message: `Failed to save file: ${String(error)}` };
       }
@@ -4520,6 +4600,50 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
   // RPC: 取消订阅项目文件树更新
   ipcMainHandle('unwatch-project-tree', async (_event, cwd: string) => {
     closeProjectTreeWatcher(cwd);
+    return true;
+  });
+
+  // RPC: 订阅单个可编辑文件的磁盘变化（用于编辑器同步外部改动）
+  ipcMainHandle('watch-project-file', async (_event, cwd: string, filePath: string) => {
+    if (!cwd || !filePath) {
+      return false;
+    }
+    const resolved = resolve(cwd, filePath);
+    const ext = extname(resolved).toLowerCase();
+    if (ext !== '.md' && ext !== '.mdx' && ext !== '.txt') {
+      return false;
+    }
+    const validation = await validateProjectFilePath(cwd, resolved);
+    if (!validation.ok) {
+      return false;
+    }
+
+    const key = projectFileWatchKey(cwd, filePath);
+    const base = basename(resolved);
+    // Close any stale watcher pointing at a different file under the same key bucket.
+    const existing = projectFileWatchers.get(key);
+    if (existing) {
+      return true;
+    }
+
+    try {
+      // Watch the parent directory (not the file) so atomic saves that rename
+      // the file into place still surface changes.
+      const watcher = watch(dirname(resolved), (_eventType, changed) => {
+        if (changed && basename(String(changed)) !== base) return;
+        scheduleProjectFile(mainWindow, key);
+      });
+      projectFileWatchers.set(key, { watcher, cwd, filePath, base });
+      return true;
+    } catch (error) {
+      console.error('Failed to watch project file:', error);
+      return false;
+    }
+  });
+
+  // RPC: 取消订阅单个文件的磁盘变化
+  ipcMainHandle('unwatch-project-file', async (_event, cwd: string, filePath: string) => {
+    closeProjectFileWatcher(projectFileWatchKey(cwd, filePath));
     return true;
   });
 

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -54,7 +54,147 @@ let latestUpdateStatus: AppUpdateStatus = {
 };
 let latestUiResumeState: import('../shared/types').UiResumeState | null = null;
 let isQuitting = false;
+let allowCloseAfterProjectEditorFlush = false;
+let projectEditorCloseFlushInProgress = false;
+
+// Mirror the current unsaved editor content in the main process so close/quit
+// can write it synchronously without depending on late renderer IPC.
+type PendingProjectEditorDraft = {
+  cwd: string;
+  filePath: string;
+  content: string;
+};
+let pendingProjectEditorDraft: PendingProjectEditorDraft | null = null;
+const EDITABLE_PROJECT_EDITOR_EXTENSIONS = new Set(['.txt', '.md', '.mdx']);
+let handledTerminationSignal = false;
+
+function setPendingProjectEditorDraft(draft: PendingProjectEditorDraft | null): void {
+  pendingProjectEditorDraft =
+    draft && typeof draft.filePath === 'string' && draft.filePath.length > 0
+      ? { cwd: draft.cwd || '', filePath: draft.filePath, content: draft.content ?? '' }
+      : null;
+}
+
+// Synchronous close/quit fallback. Only writes existing editable text files
+// inside the current project root.
+function flushPendingProjectEditorDraftSync(): void {
+  const draft = pendingProjectEditorDraft;
+  if (!draft) return;
+  pendingProjectEditorDraft = null;
+  try {
+    const root = path.resolve(draft.cwd || '.');
+    const resolved = path.resolve(root, draft.filePath || '');
+    const ext = path.extname(resolved).toLowerCase();
+    if (!EDITABLE_PROJECT_EDITOR_EXTENSIONS.has(ext)) {
+      return;
+    }
+    const rel = path.relative(root, resolved);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      return;
+    }
+    const stat = fs.existsSync(resolved) ? fs.statSync(resolved) : null;
+    if (!stat?.isFile()) {
+      return;
+    }
+    const tempPath = path.join(
+      path.dirname(resolved),
+      `.${path.basename(resolved)}.${process.pid}.${Date.now()}.${Math.random()
+        .toString(36)
+        .slice(2)}.tmp`
+    );
+    try {
+      fs.writeFileSync(tempPath, draft.content ?? '', { encoding: 'utf8', mode: stat.mode });
+      fs.renameSync(tempPath, resolved);
+    } finally {
+      try {
+        if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+      } catch {
+        // ignore cleanup failures
+      }
+    }
+  } catch (error) {
+    console.warn('[ProjectEditor] Failed to flush pending draft synchronously:', error);
+  }
+}
+
+function flushPendingProjectEditorDraftForTermination(signal: NodeJS.Signals): void {
+  if (handledTerminationSignal) return;
+  handledTerminationSignal = true;
+  isQuitting = true;
+  logDevLifecycle('process.signal', { signal });
+  flushPendingProjectEditorDraftSync();
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    saveWindowState(mainWindow);
+  }
+  if (latestUiResumeState) {
+    saveUiResumeState(latestUiResumeState);
+  }
+  try {
+    devFileWatcher?.close();
+  } catch {
+    // ignore cleanup failures during termination
+  }
+  devFileWatcher = null;
+  disposeBrowserIpc();
+  cleanup();
+  process.exit(0);
+}
+
+process.once('SIGINT', flushPendingProjectEditorDraftForTermination);
+process.once('SIGTERM', flushPendingProjectEditorDraftForTermination);
+
 const RELEASES_URL = 'https://github.com/DylanDDeng/bubble-cowork/releases';
+const PROJECT_EDITOR_FLUSH_REQUEST_CHANNEL = 'project-editor-flush-request';
+const PROJECT_EDITOR_FLUSH_RESPONSE_CHANNEL = 'project-editor-flush-response';
+
+type ProjectEditorFlushResponse = {
+  requestId?: string;
+  ok?: boolean;
+  message?: string;
+};
+
+function requestProjectEditorFlush(
+  win: BrowserWindow,
+  timeoutMs = 5000
+): Promise<{ ok: boolean; message?: string }> {
+  if (win.isDestroyed() || win.webContents.isDestroyed()) {
+    return Promise.resolve({ ok: true });
+  }
+
+  const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: { ok: boolean; message?: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      ipcMain.removeListener(PROJECT_EDITOR_FLUSH_RESPONSE_CHANNEL, handleResponse);
+      resolve(result);
+    };
+    const handleResponse = (_event: Electron.IpcMainEvent, response: ProjectEditorFlushResponse) => {
+      if (!response || response.requestId !== requestId) return;
+      finish({
+        ok: response.ok !== false,
+        message: response.message,
+      });
+    };
+    const timeoutId = setTimeout(() => {
+      finish({ ok: false, message: 'Timed out while saving the project editor before closing.' });
+    }, timeoutMs);
+
+    ipcMain.on(PROJECT_EDITOR_FLUSH_RESPONSE_CHANNEL, handleResponse);
+
+    try {
+      win.webContents.send(PROJECT_EDITOR_FLUSH_REQUEST_CHANNEL, { requestId });
+    } catch (error) {
+      finish({
+        ok: false,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+}
 
 function getMainWindowBackgroundColor(): string {
   return nativeTheme.shouldUseDarkColors ? '#111214' : '#ffffff';
@@ -352,7 +492,10 @@ function createWindow(): void {
       contextIsolation: true,
       nodeIntegration: false,
       plugins: true,
-      sandbox: false, // better-sqlite3 需要
+      sandbox: false, // required by better-sqlite3
+      // Keep debounce timers running in the background so editor autosave
+      // still fires when the user switches away and immediately quits.
+      backgroundThrottling: false,
     },
   });
 
@@ -411,24 +554,62 @@ function createWindow(): void {
 
   // 保存窗口状态
   mainWindow.on('close', (event) => {
+    const win = mainWindow;
     logDevLifecycle('mainWindow.close', {
       isQuitting,
       visible: mainWindow?.isVisible() ?? false,
       destroyed: mainWindow?.isDestroyed() ?? false,
     });
-    if (!mainWindow) {
+    if (!win) {
       return;
     }
 
-    saveWindowState(mainWindow);
+    saveWindowState(win);
     if (latestUiResumeState) {
       saveUiResumeState(latestUiResumeState);
     }
 
-    if (process.platform === 'darwin' && !isQuitting) {
-      event.preventDefault();
-      mainWindow.hide();
+    if (allowCloseAfterProjectEditorFlush) {
+      allowCloseAfterProjectEditorFlush = false;
+      return;
     }
+
+    // Write the mirrored draft before the async renderer flush. The second
+    // allowed close must not flush again because the mirror may be stale after
+    // the renderer has already saved newer content.
+    flushPendingProjectEditorDraftSync();
+
+    event.preventDefault();
+    if (projectEditorCloseFlushInProgress) {
+      return;
+    }
+
+    projectEditorCloseFlushInProgress = true;
+    void (async () => {
+      const flushResult = await requestProjectEditorFlush(win);
+      projectEditorCloseFlushInProgress = false;
+
+      if (!flushResult.ok) {
+        console.warn('[ProjectEditor] Failed to flush before close:', flushResult.message);
+      }
+
+      if (win.isDestroyed()) {
+        return;
+      }
+
+      saveWindowState(win);
+      if (latestUiResumeState) {
+        saveUiResumeState(latestUiResumeState);
+      }
+
+      if (process.platform === 'darwin' && !isQuitting) {
+        win.hide();
+        return;
+      }
+
+      allowCloseAfterProjectEditorFlush = true;
+      win.close();
+    })();
   });
 
   mainWindow.on('closed', () => {
@@ -704,6 +885,22 @@ app.whenReady().then(() => {
     saveUiResumeState(state);
     event.returnValue = { ok: true };
   });
+  // Keep the pending editor draft mirrored in the main process. Normal edits
+  // use async IPC; blur/unload paths use sync IPC before the renderer freezes.
+  ipcMain.on('project-editor-draft-update', (_event, draft: PendingProjectEditorDraft | null) => {
+    setPendingProjectEditorDraft(draft);
+  });
+  ipcMain.on('project-editor-draft-update-sync', (event, draft: PendingProjectEditorDraft | null) => {
+    setPendingProjectEditorDraft(draft);
+    event.returnValue = { ok: true };
+  });
+  // Called from beforeunload/pagehide to synchronously finish the file write
+  // without depending on close/before-quit ordering or in-flight async IPC.
+  ipcMain.on('write-project-text-file-sync', (event, draft: PendingProjectEditorDraft | null) => {
+    setPendingProjectEditorDraft(draft);
+    flushPendingProjectEditorDraftSync();
+    event.returnValue = { ok: true };
+  });
   ipcMainHandle('get-app-version', async () => {
     return app.getVersion();
   });
@@ -727,7 +924,7 @@ app.whenReady().then(() => {
 // 窗口全部关闭时退出（macOS 除外）
 app.on('window-all-closed', () => {
   logDevLifecycle('app.window-all-closed', { platform: process.platform });
-  if (process.platform !== 'darwin') {
+  if (process.platform !== 'darwin' || isQuitting) {
     app.quit();
   }
 });
@@ -736,6 +933,8 @@ app.on('window-all-closed', () => {
 app.on('before-quit', () => {
   logDevLifecycle('app.before-quit');
   isQuitting = true;
+  // Persist unsaved editor content before cleanup tears down shared resources.
+  flushPendingProjectEditorDraftSync();
   if (mainWindow && !mainWindow.isDestroyed()) {
     saveWindowState(mainWindow);
   }
@@ -750,6 +949,8 @@ app.on('before-quit', () => {
 
 app.on('will-quit', () => {
   logDevLifecycle('app.will-quit');
+  // Last fallback for quit paths that bypass before-quit.
+  flushPendingProjectEditorDraftSync();
 });
 
 app.on('child-process-gone', (_event, details) => {

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -58,6 +58,36 @@ const BROWSER_CHANNELS = {
   sendSelection: 'desktop:browser-send-selection',
 } as const;
 
+const PROJECT_EDITOR_FLUSH_REQUEST_CHANNEL = 'project-editor-flush-request';
+const PROJECT_EDITOR_FLUSH_RESPONSE_CHANNEL = 'project-editor-flush-response';
+
+type ProjectEditorFlushResult = { ok: boolean; message?: string };
+type ProjectEditorFlushHandler = () => ProjectEditorFlushResult | Promise<ProjectEditorFlushResult>;
+
+let projectEditorFlushHandler: ProjectEditorFlushHandler | null = null;
+
+ipcRenderer.on(
+  PROJECT_EDITOR_FLUSH_REQUEST_CHANNEL,
+  async (_event: unknown, request: { requestId?: string } | null) => {
+    try {
+      const result = projectEditorFlushHandler
+        ? await projectEditorFlushHandler()
+        : { ok: true };
+      ipcRenderer.send(PROJECT_EDITOR_FLUSH_RESPONSE_CHANNEL, {
+        requestId: request?.requestId,
+        ok: result?.ok !== false,
+        message: result?.message,
+      });
+    } catch (error) {
+      ipcRenderer.send(PROJECT_EDITOR_FLUSH_RESPONSE_CHANNEL, {
+        requestId: request?.requestId,
+        ok: false,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+);
+
 // 暴露 API 到渲染进程
 contextBridge.exposeInMainWorld('electron', {
   // 订阅服务器事件
@@ -107,6 +137,15 @@ contextBridge.exposeInMainWorld('electron', {
     ipcRenderer.on('window-shell-state', handler);
     return () => {
       ipcRenderer.removeListener('window-shell-state', handler);
+    };
+  },
+
+  registerProjectEditorFlushHandler: (callback: ProjectEditorFlushHandler) => {
+    projectEditorFlushHandler = callback;
+    return () => {
+      if (projectEditorFlushHandler === callback) {
+        projectEditorFlushHandler = null;
+      }
     };
   },
 
@@ -166,6 +205,35 @@ contextBridge.exposeInMainWorld('electron', {
 
   saveUiResumeState: (state: UiResumeState) => {
     return Promise.resolve(ipcRenderer.sendSync('save-ui-resume-state-sync', state));
+  },
+
+  // Mirror unsaved editor content to the main process during normal edits.
+  updateProjectEditorDraft: (
+    draft: { cwd: string; filePath: string; content: string } | null
+  ) => {
+    ipcRenderer.send('project-editor-draft-update', draft);
+  },
+
+  // Use sync IPC at blur/hidden/unload boundaries before the renderer freezes.
+  commitProjectEditorDraftSync: (
+    draft: { cwd: string; filePath: string; content: string } | null
+  ) => {
+    try {
+      ipcRenderer.sendSync('project-editor-draft-update-sync', draft);
+    } catch {
+      // ignore - best-effort flush during teardown
+    }
+  },
+
+  // Synchronously block during renderer teardown until the file write finishes.
+  writeProjectTextFileSync: (
+    draft: { cwd: string; filePath: string; content: string }
+  ) => {
+    try {
+      ipcRenderer.sendSync('write-project-text-file-sync', draft);
+    } catch {
+      // ignore - best-effort write during teardown
+    }
   },
 
   loadOlderSessionHistory: (sessionId: string, cursor: string, limit?: number) => {
@@ -451,6 +519,16 @@ contextBridge.exposeInMainWorld('electron', {
   // 取消订阅项目文件树更新
   unwatchProjectTree: (cwd: string) => {
     return ipcRenderer.invoke('unwatch-project-tree', cwd);
+  },
+
+  // 订阅单个可编辑文件的磁盘变化
+  watchProjectFile: (cwd: string, filePath: string) => {
+    return ipcRenderer.invoke('watch-project-file', cwd, filePath);
+  },
+
+  // 取消订阅单个文件的磁盘变化
+  unwatchProjectFile: (cwd: string, filePath: string) => {
+    return ipcRenderer.invoke('unwatch-project-file', cwd, filePath);
   },
 
   // Git 变更

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -545,6 +545,17 @@ export type ServerEvent =
   | { type: 'permission.request'; payload: PermissionRequestPayload }
   | { type: 'runner.error'; payload: { message: string; sessionId?: string } }
   | { type: 'project.tree'; payload: { cwd: string; tree: ProjectTreeNode | null } }
+  | {
+      type: 'project.file';
+      payload: {
+        cwd: string;
+        filePath: string;
+        text: string;
+        mtimeMs: number;
+        size: number;
+        exists: boolean;
+      };
+    }
   | { type: 'app.update'; payload: AppUpdateStatus }
   // MCP 事件
   | { type: 'mcp.config'; payload: {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -61,6 +61,9 @@ declare global {
     sendClientEvent: (event: ClientEvent) => void;
     onTerminalEvent: (callback: (event: { type: 'data' | 'exit'; sessionId: string; data?: string; exitCode?: number | null }) => void) => () => void;
     onWindowShellState: (callback: (state: { rounded: boolean }) => void) => () => void;
+    registerProjectEditorFlushHandler: (
+      callback: () => { ok: boolean; message?: string } | Promise<{ ok: boolean; message?: string }>
+    ) => () => void;
     generateSessionTitle: (prompt: string) => Promise<string>;
     getRecentCwds: (limit?: number) => Promise<string[]>;
     startTerminalSession: (sessionId: string, cwd: string, cols?: number, rows?: number) => Promise<{ ok: boolean; history?: string; message?: string }>;
@@ -74,6 +77,15 @@ declare global {
     getUiResumeState: () => Promise<UiResumeState | null>;
     getUiResumeStateSync: () => UiResumeState | null;
     saveUiResumeState: (state: UiResumeState) => Promise<{ ok: boolean }>;
+    updateProjectEditorDraft: (
+      draft: { cwd: string; filePath: string; content: string } | null
+    ) => void;
+    commitProjectEditorDraftSync: (
+      draft: { cwd: string; filePath: string; content: string } | null
+    ) => void;
+    writeProjectTextFileSync: (
+      draft: { cwd: string; filePath: string; content: string }
+    ) => void;
     loadOlderSessionHistory: (sessionId: string, cursor: string, limit?: number) => Promise<import('./shared/types').SessionHistoryPayload>;
     loadSessionHistoryAround: (
       sessionId: string,
@@ -140,13 +152,15 @@ declare global {
     createMarkdownImageAsset: (cwd: string, markdownFilePath: string, fileName: string, mimeType: string | undefined, data: Uint8Array) => Promise<{ ok: boolean; relativePath?: string; name?: string; message?: string }>;
     createInlineTextAttachment: (cwd: string, text: string) => Promise<Attachment | null>;
     createInlineImageAttachment: (mimeType: string, data: Uint8Array) => Promise<Attachment | null>;
-    writeProjectTextFile: (cwd: string, filePath: string, content: string) => Promise<{ ok: boolean; message?: string }>;
+    writeProjectTextFile: (cwd: string, filePath: string, content: string) => Promise<{ ok: boolean; message?: string; size?: number; mtimeMs?: number }>;
     previewArtifactPath: (cwd: string, filePath: string, options?: { openInBrowser?: boolean }) => Promise<{ ok: boolean; url?: string; message?: string }>;
     openPath: (filePath: string) => Promise<{ ok: boolean; message?: string }>;
     revealPath: (filePath: string) => Promise<{ ok: boolean; message?: string }>;
     getProjectTree: (cwd: string) => Promise<ProjectTreeNode | null>;
     watchProjectTree: (cwd: string) => Promise<boolean>;
     unwatchProjectTree: (cwd: string) => Promise<boolean>;
+    watchProjectFile: (cwd: string, filePath: string) => Promise<boolean>;
+    unwatchProjectFile: (cwd: string, filePath: string) => Promise<boolean>;
     getGitChanges: (cwd: string) => Promise<{ ok: boolean; error: string | null; entries: Array<{ filePath: string; status: string; staged: boolean }> }>;
     getGitWorkingTreeSummary: (cwd: string) => Promise<{ ok: boolean; error: string | null; insertions: number; deletions: number }>;
     getGitOverview: (cwd: string) => Promise<{

--- a/src/ui/components/ProjectMarkdownEditor.tsx
+++ b/src/ui/components/ProjectMarkdownEditor.tsx
@@ -96,15 +96,17 @@ type ProjectMarkdownEditorProps = {
   toolbarActions?: ReactNode;
   saveState: SaveState;
   saveError: string | null;
-  externalChange: boolean;
   onChange: (next: string) => void;
   onSave: () => void;
-  onReloadExternal: () => void;
-  onKeepLocal: () => void;
+  onRegisterBridge?: (bridge: ProjectMarkdownEditorBridge | null) => void;
+};
+
+export type ProjectMarkdownEditorBridge = {
+  flush: () => void;
+  isComposing: () => boolean;
 };
 
 type PendingLocalMarkdownValue = {
-  baseValue: string;
   latestValue: string;
   localValues: Set<string>;
 };
@@ -661,6 +663,28 @@ function createImageInputPlugin(
   });
 }
 
+function createCompositionTrackingPlugin(
+  onCompositionStart: () => void,
+  onCompositionEnd: () => void
+) {
+  return $prose(() => {
+    return new Plugin({
+      props: {
+        handleDOMEvents: {
+          compositionstart: () => {
+            onCompositionStart();
+            return false;
+          },
+          compositionend: () => {
+            onCompositionEnd();
+            return false;
+          },
+        },
+      },
+    });
+  });
+}
+
 function nodeIsActive(view: ProseEditorView | null, nodeName: string, attrs?: Record<string, unknown>): boolean {
   if (!view) return false;
   const { $from } = view.state.selection;
@@ -728,11 +752,9 @@ export function ProjectMarkdownEditor({
   toolbarActions,
   saveState,
   saveError,
-  externalChange,
   onChange,
   onSave,
-  onReloadExternal,
-  onKeepLocal,
+  onRegisterBridge,
 }: ProjectMarkdownEditorProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<Editor | null>(null);
@@ -740,9 +762,11 @@ export function ProjectMarkdownEditor({
   const currentFullMarkdownRef = useRef(value);
   const frontmatterRef = useRef(splitFrontmatter(value).frontmatter);
   const pendingLocalValueRef = useRef<PendingLocalMarkdownValue | null>(null);
-  const lastPropValueRef = useRef(value);
+  const onSaveRef = useRef(onSave);
   const applyingPropValueRef = useRef(false);
-  const previousExternalChangeRef = useRef(externalChange);
+  const composingInputRef = useRef(false);
+  const composingMarkdownRef = useRef<string | null>(null);
+  const compositionFlushTimerRef = useRef<number | null>(null);
   const outlineItemsRef = useRef<MarkdownOutlineItem[]>([]);
   const headingFlashTimerRef = useRef<number | null>(null);
   const outlineCloseTimerRef = useRef<number | null>(null);
@@ -757,6 +781,10 @@ export function ProjectMarkdownEditor({
     () => parseMarkdownMetadata(splitFrontmatter(value).frontmatter),
     [value]
   );
+
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
 
   const runCommand = useCallback(<T,>(key: { id: string } | unknown, payload?: T) => {
     const editor = editorRef.current;
@@ -891,7 +919,6 @@ export function ProjectMarkdownEditor({
       pending.localValues.add(next);
     } else {
       pendingLocalValueRef.current = {
-        baseValue: lastPropValueRef.current,
         latestValue: next,
         localValues: new Set([next]),
       };
@@ -899,6 +926,59 @@ export function ProjectMarkdownEditor({
     currentFullMarkdownRef.current = next;
     onChange(next);
   }, [onChange]);
+
+  const flushComposedMarkdown = useCallback(() => {
+    const next = composingMarkdownRef.current;
+    composingMarkdownRef.current = null;
+    if (next === null) return;
+
+    emitLocalChange(next);
+    const view = viewRef.current;
+    if (view) refreshDerivedUi(view);
+  }, [emitLocalChange, refreshDerivedUi]);
+
+  const flushPendingMarkdownToParent = useCallback(() => {
+    if (compositionFlushTimerRef.current) {
+      window.clearTimeout(compositionFlushTimerRef.current);
+      compositionFlushTimerRef.current = null;
+    }
+    composingInputRef.current = false;
+    flushComposedMarkdown();
+  }, [flushComposedMarkdown]);
+
+  const scheduleCompositionFlush = useCallback(() => {
+    if (compositionFlushTimerRef.current) {
+      window.clearTimeout(compositionFlushTimerRef.current);
+    }
+    compositionFlushTimerRef.current = window.setTimeout(() => {
+      compositionFlushTimerRef.current = null;
+      flushComposedMarkdown();
+    }, 0);
+  }, [flushComposedMarkdown]);
+
+  const handleMarkdownChange = useCallback((view: ProseEditorView, markdown: string) => {
+    const next = combineFrontmatter(frontmatterRef.current, markdown);
+    if (applyingPropValueRef.current) {
+      composingMarkdownRef.current = null;
+      currentFullMarkdownRef.current = next;
+    } else if (composingInputRef.current || view.composing) {
+      composingMarkdownRef.current = next;
+      currentFullMarkdownRef.current = next;
+    } else {
+      composingMarkdownRef.current = null;
+      emitLocalChange(next);
+    }
+    if (!composingInputRef.current && !view.composing) {
+      refreshDerivedUi(view);
+    }
+  }, [emitLocalChange, refreshDerivedUi]);
+
+  const isComposing = useCallback(() => composingInputRef.current, []);
+
+  useEffect(() => {
+    onRegisterBridge?.({ flush: flushPendingMarkdownToParent, isComposing });
+    return () => onRegisterBridge?.(null);
+  }, [flushPendingMarkdownToParent, isComposing, onRegisterBridge]);
 
   const applyFrontmatterChange = useCallback((nextFrontmatter: string) => {
     const currentParts = splitFrontmatter(currentFullMarkdownRef.current);
@@ -922,10 +1002,14 @@ export function ProjectMarkdownEditor({
     const parts = splitFrontmatter(value);
     frontmatterRef.current = parts.frontmatter;
     currentFullMarkdownRef.current = value;
-    lastPropValueRef.current = value;
     pendingLocalValueRef.current = null;
     applyingPropValueRef.current = false;
-    previousExternalChangeRef.current = externalChange;
+    composingInputRef.current = false;
+    composingMarkdownRef.current = null;
+    if (compositionFlushTimerRef.current) {
+      window.clearTimeout(compositionFlushTimerRef.current);
+      compositionFlushTimerRef.current = null;
+    }
     setEditorFocused(false);
     let disposed = false;
 
@@ -953,13 +1037,7 @@ export function ProjectMarkdownEditor({
           ctx.set(defaultValueCtx, parts.body);
           const listeners = ctx.get(listenerCtx);
           listeners.markdownUpdated((innerCtx, markdown) => {
-            const next = combineFrontmatter(frontmatterRef.current, markdown);
-            if (applyingPropValueRef.current) {
-              currentFullMarkdownRef.current = next;
-            } else {
-              emitLocalChange(next);
-            }
-            refreshDerivedUi(innerCtx.get(editorViewCtx));
+            handleMarkdownChange(innerCtx.get(editorViewCtx), markdown);
           });
           listeners.focus((innerCtx) => {
             setEditorFocused(true);
@@ -974,6 +1052,19 @@ export function ProjectMarkdownEditor({
         .use(gfm)
         .use(history)
         .use(listener)
+        .use(createCompositionTrackingPlugin(
+          () => {
+            composingInputRef.current = true;
+            if (compositionFlushTimerRef.current) {
+              window.clearTimeout(compositionFlushTimerRef.current);
+              compositionFlushTimerRef.current = null;
+            }
+          },
+          () => {
+            composingInputRef.current = false;
+            scheduleCompositionFlush();
+          }
+        ))
         .use(createImageInputPlugin(insertImageFiles))
         .use(clipboard)
         .use(trailingParagraphPlugin)
@@ -999,6 +1090,7 @@ export function ProjectMarkdownEditor({
 
     return () => {
       disposed = true;
+      flushPendingMarkdownToParent();
       const editor = editorRef.current;
       editorRef.current = null;
       viewRef.current = null;
@@ -1009,35 +1101,30 @@ export function ProjectMarkdownEditor({
         window.clearTimeout(headingFlashTimerRef.current);
         headingFlashTimerRef.current = null;
       }
+      if (compositionFlushTimerRef.current) {
+        window.clearTimeout(compositionFlushTimerRef.current);
+        compositionFlushTimerRef.current = null;
+      }
+      composingInputRef.current = false;
+      composingMarkdownRef.current = null;
     };
-  }, [cwd, emitLocalChange, filePath, refreshDerivedUi]);
+  }, [cwd, filePath, flushPendingMarkdownToParent, handleMarkdownChange, refreshDerivedUi, scheduleCompositionFlush]);
 
   useEffect(() => {
-    const wasExternalChange = previousExternalChangeRef.current;
-    const resolvedExternalChange = wasExternalChange && !externalChange;
-    previousExternalChangeRef.current = externalChange;
-
     const editor = editorRef.current;
     const pending = pendingLocalValueRef.current;
     if (pending) {
       if (value === pending.latestValue) {
         pendingLocalValueRef.current = null;
-        lastPropValueRef.current = value;
         return;
       }
 
-      if (
-        !resolvedExternalChange &&
-        (value === pending.baseValue || pending.localValues.has(value))
-      ) {
-        lastPropValueRef.current = value;
+      if (pending.localValues.has(value)) {
         return;
       }
 
       pendingLocalValueRef.current = null;
     }
-
-    lastPropValueRef.current = value;
 
     if (!editor) {
       const parts = splitFrontmatter(value);
@@ -1057,18 +1144,18 @@ export function ProjectMarkdownEditor({
       applyingPropValueRef.current = false;
     }
     editor.action((ctx) => refreshDerivedUi(ctx.get(editorViewCtx)));
-  }, [externalChange, refreshDerivedUi, value]);
+  }, [refreshDerivedUi, value]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
         event.preventDefault();
-        onSave();
+        onSaveRef.current();
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [onSave]);
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -1182,14 +1269,6 @@ export function ProjectMarkdownEditor({
           </div>
         ) : null}
       </div>
-
-      {externalChange && (
-        <div className="aegis-md-conflict">
-          <span>The file changed on disk while this document was open.</span>
-          <button type="button" onClick={onReloadExternal}>Reload disk version</button>
-          <button type="button" onClick={onKeepLocal}>Keep my edits</button>
-        </div>
-      )}
 
       {saveState === 'error' && saveError && (
         <div className="aegis-md-error">{saveError}</div>

--- a/src/ui/components/ProjectTreePanel.tsx
+++ b/src/ui/components/ProjectTreePanel.tsx
@@ -8,7 +8,7 @@ import { MDContent } from '../render/markdown';
 import { HighlightedCode } from './HighlightedCode';
 import TextFileReader from './TextFileReader';
 import { FileTypeIcon } from './FileTypeIcon';
-import { ProjectMarkdownEditor } from './ProjectMarkdownEditor';
+import { ProjectMarkdownEditor, type ProjectMarkdownEditorBridge } from './ProjectMarkdownEditor';
 import { ProjectMdxPreview, ProjectMdxProperties, parseMdxDocument } from './ProjectMdxPreview';
 import { ProjectTextEditor } from './ProjectTextEditor';
 import { IconButton } from './ui/icon-button';
@@ -27,6 +27,7 @@ import type { ProjectTreeNode } from '../types';
 
 type ProjectPanelTab = 'files' | 'changes';
 type ViewMode = 'view' | 'code' | 'split';
+type ProjectEditorFlushResult = { ok: boolean; message?: string };
 type ProjectPanelDimensions = {
   defaultWidth: number;
   minWidth: number;
@@ -70,6 +71,7 @@ type ProjectFilePreview =
       name: string;
       ext: string;
       size: number;
+      mtimeMs: number;
       text: string;
       editable: boolean;
     }
@@ -560,7 +562,84 @@ export function ProjectTreePanel({
   const [draftText, setDraftText] = useState('');
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [externalDiskText, setExternalDiskText] = useState<string | null>(null);
+  const draftTextRef = useRef('');
+  const saveErrorRef = useRef<string | null>(null);
+  const saveStateRef = useRef<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const selectedEditableTextPreviewRef = useRef<ProjectFilePreview | null>(null);
+  const activeMarkdownBridgeRef = useRef<ProjectMarkdownEditorBridge | null>(null);
+  // Every disk content we have loaded, saved, or applied for the open file.
+  // The watcher only treats an event as a genuine external change when its
+  // content is NOT in this set. A set (not a single value) is required because
+  // the editor's serialization jitters between keystrokes and autosave writes
+  // several variants, while watcher events arrive debounced and out of order.
+  const knownDiskContentsRef = useRef<Set<string>>(new Set());
+  const rememberDiskContent = useCallback((text: string) => {
+    const set = knownDiskContentsRef.current;
+    set.add(text);
+    if (set.size > 64) {
+      const oldest = set.values().next().value;
+      if (oldest !== undefined) set.delete(oldest);
+    }
+  }, []);
+  const pendingExternalReloadRef = useRef<{
+    cwd: string;
+    filePath: string;
+    text: string;
+    mtimeMs: number;
+    size: number;
+    exists: boolean;
+  } | null>(null);
+  const saveInFlightRef = useRef(false);
+  const saveAgainAfterInFlightRef = useRef(false);
+  const savePromiseRef = useRef<Promise<boolean> | null>(null);
+  const projectEditorFlushRef = useRef<() => Promise<ProjectEditorFlushResult>>(async () => ({ ok: true }));
+  const setDraftTextSynced = useCallback((next: string) => {
+    draftTextRef.current = next;
+    if (saveInFlightRef.current) {
+      saveAgainAfterInFlightRef.current = true;
+    }
+    setDraftText(next);
+  }, []);
+  const mirrorProjectEditorDraftSync = useCallback(
+    (next: string) => {
+      const preview = selectedEditableTextPreviewRef.current;
+      if (
+        selectedFileCwd &&
+        selectedFilePath &&
+        preview &&
+        (preview.kind === 'markdown' || preview.kind === 'text') &&
+        preview.editable &&
+        next !== preview.text
+      ) {
+        window.electron.commitProjectEditorDraftSync?.({
+          cwd: selectedFileCwd,
+          filePath: selectedFilePath,
+          content: next,
+        });
+        return;
+      }
+      window.electron.commitProjectEditorDraftSync?.(null);
+    },
+    [selectedFileCwd, selectedFilePath]
+  );
+  const handleDraftTextChange = useCallback(
+    (next: string) => {
+      setDraftTextSynced(next);
+      mirrorProjectEditorDraftSync(next);
+    },
+    [mirrorProjectEditorDraftSync, setDraftTextSynced]
+  );
+  const setSaveStateSynced = useCallback((next: 'idle' | 'saving' | 'saved' | 'error') => {
+    saveStateRef.current = next;
+    setSaveState(next);
+  }, []);
+  const setSaveErrorSynced = useCallback((next: string | null) => {
+    saveErrorRef.current = next;
+    setSaveError(next);
+  }, []);
+  const registerMarkdownBridge = useCallback((bridge: ProjectMarkdownEditorBridge | null) => {
+    activeMarkdownBridgeRef.current = bridge;
+  }, []);
   const copiedTimerRef = useRef<number | null>(null);
   const [copiedPath, setCopiedPath] = useState(false);
   const createDraftIdRef = useRef(0);
@@ -810,9 +889,9 @@ export function ProjectTreePanel({
     setViewMode('view');
     setMdxRevealTarget(null);
     setPreviewLoading(false);
-    setDraftText('');
-    setSaveState('idle');
-    setSaveError(null);
+    setDraftTextSynced('');
+    setSaveStateSynced('idle');
+    setSaveErrorSynced(null);
     setProjectTreeError(null);
     setPptxSlideIndex(0);
     setCreateDraft(null);
@@ -824,7 +903,7 @@ export function ProjectTreePanel({
     setChangeRecords([]);
     setChangesError(null);
     setExpandedChangeId(null);
-  }, [cwd]);
+  }, [cwd, setDraftTextSynced, setSaveStateSynced]);
 
   useEffect(() => {
     setPanelWidth((current) =>
@@ -925,10 +1004,9 @@ export function ProjectTreePanel({
       setPreviewLoading(false);
       setSelectedPreview(null);
       setMdxRevealTarget(null);
-      setDraftText('');
-      setSaveState('idle');
-      setSaveError(null);
-      setExternalDiskText(null);
+      setDraftTextSynced('');
+      setSaveStateSynced('idle');
+      setSaveErrorSynced(null);
       setPptxSlideIndex(0);
 
       if (!activeSessionId) {
@@ -959,10 +1037,9 @@ export function ProjectTreePanel({
     setMdxRevealTarget(null);
     setPreviewLoading(true);
     setSelectedPreview(null);
-    setDraftText('');
-    setSaveState('idle');
-    setSaveError(null);
-    setExternalDiskText(null);
+    setDraftTextSynced('');
+    setSaveStateSynced('idle');
+    setSaveErrorSynced(null);
     setPptxSlideIndex(0);
 
     const reader = window.electron.readProjectFilePreview;
@@ -985,12 +1062,12 @@ export function ProjectTreePanel({
       if (previewRequestIdRef.current !== requestId) return;
       setSelectedPreview(preview);
       if (preview.kind === 'text' && preview.ext === '.mdx') {
-        setDraftText(preview.text);
+        setDraftTextSynced(preview.text);
         setViewMode('code');
         return;
       }
       if ((preview.kind === 'text' || preview.kind === 'markdown') && preview.editable) {
-        setDraftText(preview.text);
+        setDraftTextSynced(preview.text);
       }
     } catch (error) {
       if (previewRequestIdRef.current !== requestId) return;
@@ -1013,6 +1090,8 @@ export function ProjectTreePanel({
     selectedFilePath,
     setBrowserPanelOpen,
     setProjectTreeCollapsed,
+    setDraftTextSynced,
+    setSaveStateSynced,
   ]);
 
   const selectFile = async (node: ProjectTreeNode) => {
@@ -1307,10 +1386,9 @@ export function ProjectTreePanel({
     setMdxRevealTarget(null);
     setPreviewLoading(true);
     setSelectedPreview(null);
-    setDraftText('');
-    setSaveState('idle');
-    setSaveError(null);
-    setExternalDiskText(null);
+    setDraftTextSynced('');
+    setSaveStateSynced('idle');
+    setSaveErrorSynced(null);
     setPptxSlideIndex(0);
 
     const requestId = (previewRequestIdRef.current += 1);
@@ -1320,7 +1398,7 @@ export function ProjectTreePanel({
       // MDX files: use CodeMirror plain-text editor (default), with toggle to rendered preview.
       if (preview.kind === 'text' && preview.ext === '.mdx') {
         setSelectedPreview(preview);
-        setDraftText(preview.text);
+        setDraftTextSynced(preview.text);
         setViewMode('code'); // default to source editing like Cursor
         if (typeof options.lineStart === 'number') {
           mdxRevealTokenRef.current += 1;
@@ -1334,7 +1412,7 @@ export function ProjectTreePanel({
       if (preview.kind === 'markdown') {
         setSelectedPreview(preview);
         if (preview.editable) {
-          setDraftText(preview.text);
+          setDraftTextSynced(preview.text);
         }
         return;
       }
@@ -1350,6 +1428,7 @@ export function ProjectTreePanel({
           }`,
           ext: preview.ext,
           size: preview.size,
+          mtimeMs: preview.mtimeMs,
           text: sliceTextLineRange(preview.text, options.lineStart, options.lineEnd),
           editable: false,
         });
@@ -1374,7 +1453,7 @@ export function ProjectTreePanel({
         setPreviewLoading(false);
       }
     }
-  }, []);
+  }, [setDraftTextSynced, setSaveStateSynced]);
 
   const closePreview = useCallback(() => {
     setSelectedFilePath(null);
@@ -1382,13 +1461,12 @@ export function ProjectTreePanel({
     setSelectedPreview(null);
     setViewMode('view');
     setMdxRevealTarget(null);
-    setDraftText('');
-    setSaveState('idle');
-    setSaveError(null);
-    setExternalDiskText(null);
+    setDraftTextSynced('');
+    setSaveStateSynced('idle');
+    setSaveErrorSynced(null);
     setPptxSlideIndex(0);
     if (isFullscreen && onToggleFullscreen) onToggleFullscreen();
-  }, [isFullscreen, onToggleFullscreen]);
+  }, [isFullscreen, onToggleFullscreen, setDraftTextSynced, setSaveStateSynced]);
 
   const deleteEntry = useCallback(async (node: ProjectTreeNode) => {
     if (!cwd) return;
@@ -1554,134 +1632,372 @@ export function ProjectTreePanel({
     selectedPreview.editable
       ? selectedPreview
       : null;
+  const hasEditableTextOpen = Boolean(selectedEditableTextPreview);
+
+  useEffect(() => {
+    draftTextRef.current = draftText;
+  }, [draftText]);
+
+  useEffect(() => {
+    saveStateRef.current = saveState;
+  }, [saveState]);
+
+  useEffect(() => {
+    selectedEditableTextPreviewRef.current = selectedEditableTextPreview;
+  }, [selectedEditableTextPreview]);
+
+  // Mirror unsaved text to the main process for the synchronous quit fallback.
+  useEffect(() => {
+    const updateDraft = window.electron.updateProjectEditorDraft;
+    if (typeof updateDraft !== 'function') return;
+    if (
+      selectedFileCwd &&
+      selectedFilePath &&
+      selectedEditableTextPreview &&
+      draftText !== selectedEditableTextPreview.text
+    ) {
+      updateDraft({ cwd: selectedFileCwd, filePath: selectedFilePath, content: draftText });
+    } else {
+      updateDraft(null);
+    }
+  }, [draftText, selectedEditableTextPreview, selectedFileCwd, selectedFilePath]);
 
   const canSaveText =
     !!selectedFileCwd &&
     !!selectedEditableTextPreview &&
     draftText !== selectedEditableTextPreview.text;
 
-  const handleSaveText = async () => {
-    if (!selectedFileCwd) return;
-    if (!selectedEditableTextPreview) {
-      return;
+  const handleSaveText = useCallback(async (): Promise<boolean> => {
+    if (!selectedFileCwd) return true;
+    const previewToSave = selectedEditableTextPreviewRef.current;
+    if (
+      !previewToSave ||
+      (previewToSave.kind !== 'markdown' && previewToSave.kind !== 'text') ||
+      (previewToSave.kind === 'text' && previewToSave.ext !== '.mdx') ||
+      !previewToSave.editable
+    ) {
+      return true;
     }
-    if (!selectedFilePath) return;
-    if (!canSaveText) return;
+    if (!selectedFilePath) return true;
+    const textToSave = draftTextRef.current;
+    if (textToSave === previewToSave.text) {
+      window.electron.commitProjectEditorDraftSync?.(null);
+      return true;
+    }
+    if (saveInFlightRef.current) {
+      saveAgainAfterInFlightRef.current = true;
+      const inFlightSave = savePromiseRef.current;
+      if (!inFlightSave) return true;
+      const inFlightOk = await inFlightSave;
+      if (!inFlightOk) return false;
+      const latestPreview = selectedEditableTextPreviewRef.current;
+      const stillDirty =
+        !!latestPreview &&
+        (latestPreview.kind === 'markdown' || latestPreview.kind === 'text') &&
+        latestPreview.editable &&
+        draftTextRef.current !== latestPreview.text;
+      return stillDirty ? handleSaveText() : true;
+    }
 
-    setSaveState('saving');
-    setSaveError(null);
-    try {
-      const result = (await window.electron.writeProjectTextFile(
-        selectedFileCwd,
-        selectedFilePath,
-        draftText
-      )) as { ok: boolean; message?: string };
-      if (!result?.ok) {
-        setSaveState('error');
-        setSaveError(result?.message || 'Failed to save');
-        return;
+    saveInFlightRef.current = true;
+    setSaveStateSynced('saving');
+    setSaveErrorSynced(null);
+
+    const savePromise = (async (): Promise<boolean> => {
+      let savedOk = false;
+      try {
+        const result = await window.electron.writeProjectTextFile(
+          selectedFileCwd,
+          selectedFilePath,
+          textToSave
+        );
+        if (!result?.ok) {
+          setSaveStateSynced('error');
+          setSaveErrorSynced(result?.message || 'Failed to save');
+          return false;
+        }
+        const savedPreview = {
+          ...previewToSave,
+          text: textToSave,
+          size: result.size ?? previewToSave.size,
+          mtimeMs: result.mtimeMs ?? previewToSave.mtimeMs,
+        };
+        selectedEditableTextPreviewRef.current = savedPreview;
+        rememberDiskContent(textToSave);
+        setSelectedPreview(savedPreview);
+        void loadChangeRecords();
+        savedOk = true;
+        setSaveStateSynced('saved');
+        window.setTimeout(() => {
+          if (saveStateRef.current === 'saved') {
+            setSaveStateSynced('idle');
+          }
+        }, 1200);
+      } catch (error) {
+        setSaveStateSynced('error');
+        setSaveErrorSynced(String(error));
+        return false;
+      } finally {
+        saveInFlightRef.current = false;
       }
-      setSelectedPreview({ ...selectedEditableTextPreview, text: draftText });
-      setExternalDiskText(null);
-      void loadChangeRecords();
-      setSaveState('saved');
-      window.setTimeout(() => setSaveState('idle'), 1200);
-    } catch (error) {
-      setSaveState('error');
-      setSaveError(String(error));
+
+      if (!savedOk) return false;
+      const currentPreview = selectedEditableTextPreviewRef.current;
+      const stillDirty =
+        !!currentPreview &&
+        (currentPreview.kind === 'markdown' || currentPreview.kind === 'text') &&
+        currentPreview.editable &&
+        draftTextRef.current !== currentPreview.text;
+      if (saveAgainAfterInFlightRef.current || stillDirty) {
+        saveAgainAfterInFlightRef.current = false;
+        return handleSaveText();
+      }
+      window.electron.commitProjectEditorDraftSync?.(null);
+      return true;
+    })();
+
+    savePromiseRef.current = savePromise;
+    const saveOk = await savePromise;
+    if (savePromiseRef.current === savePromise) {
+      savePromiseRef.current = null;
     }
-  };
+    return saveOk;
+  }, [selectedFileCwd, selectedFilePath, setSaveErrorSynced, setSaveStateSynced]);
 
   useEffect(() => {
     if (
-      !selectedPreview ||
-      selectedPreview.kind !== 'markdown' ||
-      !selectedPreview.editable ||
-      !canSaveText ||
-      externalDiskText !== null ||
-      saveState === 'saving'
+      !selectedEditableTextPreview ||
+      !canSaveText
     ) {
       return;
     }
 
     const timerId = window.setTimeout(() => {
       void handleSaveText();
-    }, 1200);
+    }, 350);
 
     return () => window.clearTimeout(timerId);
-  }, [canSaveText, draftText, externalDiskText, saveState, selectedPreview]);
+  }, [canSaveText, draftText, handleSaveText, selectedEditableTextPreview]);
+
+  const flushProjectEditorBeforeClose = useCallback(async (): Promise<ProjectEditorFlushResult> => {
+    activeMarkdownBridgeRef.current?.flush();
+    const saveOk = await handleSaveText();
+    const currentPreview = selectedEditableTextPreviewRef.current;
+    const stillDirty =
+      !!currentPreview &&
+      (currentPreview.kind === 'markdown' || currentPreview.kind === 'text') &&
+      currentPreview.editable &&
+      draftTextRef.current !== currentPreview.text;
+
+    if (!saveOk || stillDirty) {
+      return {
+        ok: false,
+        message: saveErrorRef.current || 'Failed to save pending editor changes.',
+      };
+    }
+
+    return { ok: true };
+  }, [handleSaveText]);
 
   useEffect(() => {
-    if (
-      !cwd ||
-      !selectedFileCwd ||
-      !selectedFilePath ||
-      !selectedEditableTextPreview
-    ) {
+    projectEditorFlushRef.current = flushProjectEditorBeforeClose;
+  }, [flushProjectEditorBeforeClose]);
+
+  useEffect(() => {
+    const registerFlushHandler = window.electron.registerProjectEditorFlushHandler;
+    if (typeof registerFlushHandler !== 'function') return;
+    return registerFlushHandler(() => projectEditorFlushRef.current());
+  }, []);
+
+  useEffect(() => {
+    if (!selectedFileCwd || !selectedFilePath || !selectedEditableTextPreview) {
       return;
     }
 
-    const reader = window.electron.readProjectFilePreview;
-    if (typeof reader !== 'function') return;
+    // Blur/visibility saves only the draft emitted by Milkdown. The final
+    // close path also flushes pending composition state, but never resaves a
+    // freshly serialized ProseMirror document because that can fold blank lines.
+    const getDirtyContent = (flushEditor: boolean): string | null => {
+      if (flushEditor) {
+        activeMarkdownBridgeRef.current?.flush();
+      }
+      const currentPreview = selectedEditableTextPreviewRef.current;
+      if (
+        !currentPreview ||
+        (currentPreview.kind !== 'markdown' && currentPreview.kind !== 'text') ||
+        !currentPreview.editable ||
+        draftTextRef.current === currentPreview.text
+      ) {
+        return null;
+      }
+      return draftTextRef.current;
+    };
 
-    const intervalId = window.setInterval(() => {
-      void (async () => {
-        try {
-          const latest = (await reader(selectedFileCwd, selectedFilePath)) as ProjectFilePreview;
-          if (
-            (latest.kind !== 'markdown' && latest.kind !== 'text') ||
-            !latest.editable ||
-            latest.kind !== selectedEditableTextPreview.kind ||
-            latest.ext !== selectedEditableTextPreview.ext
-          ) {
-            return;
-          }
-          if (latest.text === selectedEditableTextPreview.text) return;
+    const flushPendingDraft = () => {
+      const content = getDirtyContent(false);
+      if (content === null) return;
+      window.electron.commitProjectEditorDraftSync?.({
+        cwd: selectedFileCwd,
+        filePath: selectedFilePath,
+        content,
+      });
+      void handleSaveText();
+    };
 
-          if (draftText === selectedEditableTextPreview.text) {
-            setSelectedPreview(latest);
-            setDraftText(latest.text);
-            setExternalDiskText(null);
-          } else {
-            setExternalDiskText(latest.text);
-          }
-        } catch {
-          // Polling is only a conflict detector; preview load/save surfaces real errors.
+    const flushPendingDraftSync = () => {
+      const content = getDirtyContent(true);
+      if (content === null) return;
+      window.electron.writeProjectTextFileSync?.({
+        cwd: selectedFileCwd,
+        filePath: selectedFilePath,
+        content,
+      });
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        flushPendingDraft();
+      }
+    };
+
+    window.addEventListener('blur', flushPendingDraft);
+    window.addEventListener('pagehide', flushPendingDraftSync);
+    window.addEventListener('beforeunload', flushPendingDraftSync);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('blur', flushPendingDraft);
+      window.removeEventListener('pagehide', flushPendingDraftSync);
+      window.removeEventListener('beforeunload', flushPendingDraftSync);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [handleSaveText, selectedEditableTextPreview, selectedFileCwd, selectedFilePath]);
+
+  const applyExternalReload = useCallback(
+    (payload: { text: string; mtimeMs: number; size: number }) => {
+      const currentPreview = selectedEditableTextPreviewRef.current;
+      if (!currentPreview) return;
+      const latest = {
+        ...currentPreview,
+        text: payload.text,
+        mtimeMs: payload.mtimeMs,
+        size: payload.size,
+      };
+      selectedEditableTextPreviewRef.current = latest;
+      rememberDiskContent(payload.text);
+      setSelectedPreview(latest);
+      setDraftTextSynced(payload.text);
+      setSaveStateSynced('idle');
+      setSaveErrorSynced(null);
+    },
+    [rememberDiskContent, setDraftTextSynced, setSaveErrorSynced, setSaveStateSynced]
+  );
+
+  // Subscribe to disk changes for the open editable file. Event-driven via the
+  // main-process file watcher; replaces the previous 4s polling loop.
+  useEffect(() => {
+    if (!selectedFileCwd || !selectedFilePath || !hasEditableTextOpen) {
+      return;
+    }
+    const watcher = window.electron.watchProjectFile;
+    const unwatcher = window.electron.unwatchProjectFile;
+    if (typeof watcher !== 'function' || typeof unwatcher !== 'function') return;
+
+    void watcher(selectedFileCwd, selectedFilePath);
+    return () => {
+      void unwatcher(selectedFileCwd, selectedFilePath);
+    };
+  }, [selectedFileCwd, selectedFilePath, hasEditableTextOpen]);
+
+  // Reconcile external disk changes pushed by the file watcher.
+  useEffect(() => {
+    if (!selectedFileCwd || !selectedFilePath) return;
+
+    // New file context: drop all remembered disk content so every watcher event
+    // is evaluated fresh against whatever the file actually contains.
+    knownDiskContentsRef.current = new Set();
+
+    const handleFileChanged = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        cwd: string;
+        filePath: string;
+        text: string;
+        mtimeMs: number;
+        size: number;
+        exists: boolean;
+      }>).detail;
+      if (!detail || detail.cwd !== selectedFileCwd || detail.filePath !== selectedFilePath) {
+        return;
+      }
+
+      const currentPreview = selectedEditableTextPreviewRef.current;
+      if (
+        !currentPreview ||
+        (currentPreview.kind !== 'markdown' && currentPreview.kind !== 'text') ||
+        !currentPreview.editable
+      ) {
+        return;
+      }
+      // File removed/renamed away: keep the in-editor buffer rather than wiping it.
+      if (!detail.exists) return;
+
+      const composing = activeMarkdownBridgeRef.current?.isComposing() ?? false;
+
+      // Seed the known-contents set on the very first event so the originally
+      // loaded preview text is recognised as "ours".
+      if (knownDiskContentsRef.current.size === 0) {
+        rememberDiskContent(currentPreview.text);
+      }
+
+      // Content we have previously loaded, saved, or applied: not external.
+      // Using a set instead of a single value avoids false positives from
+      // serialization jitter (210/211) and out-of-order debounced events.
+      if (knownDiskContentsRef.current.has(detail.text)) {
+        if (detail.mtimeMs !== currentPreview.mtimeMs || detail.size !== currentPreview.size) {
+          const refreshed = {
+            ...currentPreview,
+            mtimeMs: detail.mtimeMs,
+            size: detail.size,
+          };
+          selectedEditableTextPreviewRef.current = refreshed;
+          setSelectedPreview(refreshed);
         }
-      })();
-    }, 4000);
+        return;
+      }
 
-    return () => window.clearInterval(intervalId);
-  }, [cwd, draftText, selectedEditableTextPreview, selectedFileCwd, selectedFilePath]);
+      // Never-before-seen disk content. Remember it so future echoes are ignored.
+      rememberDiskContent(detail.text);
 
-  const handleReloadMarkdownExternal = () => {
-    if (
-      !selectedEditableTextPreview ||
-      externalDiskText === null
-    ) {
-      return;
+      // The user has unsaved local edits or a save is in flight: never clobber.
+      if (draftTextRef.current !== detail.text && saveStateRef.current !== 'idle') {
+        return;
+      }
+      if (draftTextRef.current !== currentPreview.text && draftTextRef.current !== detail.text) {
+        return;
+      }
+
+      // Genuine external change with no local edits. Defer while composing.
+      if (composing) {
+        pendingExternalReloadRef.current = detail;
+        return;
+      }
+      applyExternalReload(detail);
+    };
+
+    window.addEventListener('aegis:project-file-changed', handleFileChanged);
+    return () => window.removeEventListener('aegis:project-file-changed', handleFileChanged);
+  }, [applyExternalReload, rememberDiskContent, selectedFileCwd, selectedFilePath]);
+
+  // Apply a deferred external reload once IME composition settles.
+  useEffect(() => {
+    const pending = pendingExternalReloadRef.current;
+    if (!pending) return;
+    if (activeMarkdownBridgeRef.current?.isComposing()) return;
+    pendingExternalReloadRef.current = null;
+    if (pending.text !== draftTextRef.current) {
+      applyExternalReload(pending);
     }
-
-    setSelectedPreview({ ...selectedEditableTextPreview, text: externalDiskText });
-    setDraftText(externalDiskText);
-    setExternalDiskText(null);
-    setSaveState('idle');
-    setSaveError(null);
-  };
-
-  const handleKeepMarkdownLocal = () => {
-    if (
-      !selectedEditableTextPreview ||
-      externalDiskText === null
-    ) {
-      return;
-    }
-
-    setSelectedPreview({ ...selectedEditableTextPreview, text: externalDiskText });
-    setExternalDiskText(null);
-    setSaveState('idle');
-    setSaveError(null);
-  };
+  }, [applyExternalReload, draftText]);
 
   const handlePreviewResizeMove = (clientX: number) => {
     if (!previewResizingRef.current) return;
@@ -2248,7 +2564,9 @@ export function ProjectTreePanel({
 
                     {canSaveText && (
                       <button
-                        onClick={handleSaveText}
+                        onClick={() => {
+                          void handleSaveText();
+                        }}
                         disabled={saveState === 'saving'}
                         className="px-2 py-1 text-xs rounded-md bg-[var(--accent)] text-[var(--accent-foreground)] hover:bg-[var(--accent-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
                         title="Save"
@@ -2367,7 +2685,6 @@ export function ProjectTreePanel({
                       windowControlsInset={isFullscreen}
                       saveState={saveState}
                       saveError={saveError}
-                      externalChange={externalDiskText !== null}
                       toolbarActions={
                         <>
                           {onToggleFullscreen && (
@@ -2391,10 +2708,9 @@ export function ProjectTreePanel({
                           </IconButton>
                         </>
                       }
-                      onChange={setDraftText}
+                      onChange={handleDraftTextChange}
                       onSave={handleSaveText}
-                      onReloadExternal={handleReloadMarkdownExternal}
-                      onKeepLocal={handleKeepMarkdownLocal}
+                      onRegisterBridge={registerMarkdownBridge}
                     />
                   ) : (
                     <MDContent
@@ -2428,14 +2744,14 @@ export function ProjectTreePanel({
                       <div className="aegis-mdx-editor-shell">
                         <ProjectMdxProperties
                           content={draftText}
-                          onChange={setDraftText}
+                          onChange={handleDraftTextChange}
                           onRevealSource={handleRevealMdxSource}
                           compact
                         />
                         <div className="aegis-mdx-source-fill">
                           <ProjectTextEditor
                             value={draftText}
-                            onChange={setDraftText}
+                            onChange={handleDraftTextChange}
                             onSave={() => handleSaveText()}
                             revealTarget={mdxRevealTarget}
                           />
@@ -2445,13 +2761,12 @@ export function ProjectTreePanel({
                           saveState={saveState}
                           saveError={saveError}
                           issueCount={mdxIssueCount}
-                          externalChange={externalDiskText !== null}
                         />
                       </div>
                     ) : isMdxPreviewSurface ? (
                       <ProjectMdxPreview
                         content={draftText}
-                        onChange={setDraftText}
+                        onChange={handleDraftTextChange}
                         onRevealSource={handleRevealMdxSource}
                       />
                     ) : isMdxSplitPreviewSurface ? (
@@ -2459,14 +2774,14 @@ export function ProjectTreePanel({
                         <div className="aegis-mdx-split-pane aegis-mdx-split-source">
                           <ProjectMdxProperties
                             content={draftText}
-                            onChange={setDraftText}
+                            onChange={handleDraftTextChange}
                             onRevealSource={handleRevealMdxSource}
                             compact
                           />
                           <div className="aegis-mdx-source-fill">
                             <ProjectTextEditor
                               value={draftText}
-                              onChange={setDraftText}
+                              onChange={handleDraftTextChange}
                               onSave={() => handleSaveText()}
                               revealTarget={mdxRevealTarget}
                             />
@@ -2476,13 +2791,12 @@ export function ProjectTreePanel({
                             saveState={saveState}
                             saveError={saveError}
                             issueCount={mdxIssueCount}
-                            externalChange={externalDiskText !== null}
                           />
                         </div>
                         <div className="aegis-mdx-split-pane aegis-mdx-split-preview">
                           <ProjectMdxPreview
                             content={draftText}
-                            onChange={setDraftText}
+                            onChange={handleDraftTextChange}
                             onRevealSource={handleRevealMdxSource}
                             showProperties={false}
                           />
@@ -2491,7 +2805,7 @@ export function ProjectTreePanel({
                     ) : selectedPreview.editable ? (
                       <textarea
                         value={draftText}
-                        onChange={(e) => setDraftText(e.target.value)}
+                        onChange={(e) => handleDraftTextChange(e.target.value)}
                         className="w-full h-full min-h-[220px] resize-none bg-transparent outline-none font-mono text-sm whitespace-pre-wrap"
                         spellCheck={false}
                       />
@@ -2838,13 +3152,11 @@ function MdxStatusBar({
   saveState,
   saveError,
   issueCount,
-  externalChange,
 }: {
   dirty: boolean;
   saveState: 'idle' | 'saving' | 'saved' | 'error';
   saveError: string | null;
   issueCount: number;
-  externalChange: boolean;
 }) {
   const saveLabel =
     saveState === 'saving'
@@ -2863,7 +3175,6 @@ function MdxStatusBar({
       <span>MDX</span>
       <span className={dirty || saveState === 'error' ? 'is-attention' : ''}>{saveLabel}</span>
       <span className={issueCount > 0 ? 'is-attention' : ''}>{previewLabel}</span>
-      {externalChange ? <span className="is-attention">Disk changed</span> : null}
       {saveError ? <span className="is-error">{saveError}</span> : null}
     </div>
   );

--- a/src/ui/store/useAppStore.ts
+++ b/src/ui/store/useAppStore.ts
@@ -1063,6 +1063,14 @@ export const useAppStore = create<Store>()(
         });
         break;
 
+      case 'project.file':
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(
+            new CustomEvent('aegis:project-file-changed', { detail: event.payload })
+          );
+        }
+        break;
+
       case 'app.update':
         set({
           updateStatus: {


### PR DESCRIPTION
## Summary

- persist Markdown editor drafts through normal close, app quit, and dev SIGINT/SIGTERM paths
- switch project text saves to atomic temp-file writes before replacing the target file
- replace the old disk-change prompt flow with file watcher reconciliation that does not clobber local edits
- prevent half-started dev sessions when the Vite port is already occupied

## Root Cause

Markdown edits could remain only in the renderer until the autosave debounce finished. In `npm run dev`, quitting through the terminal or process signals could end Electron before the last renderer IPC completed. The previous direct `writeFile(target)` save path also made interruption unsafe because the target file could be truncated before the new contents were fully written.

## Validation

- `npm run build`
- Playwright Electron persistence matrix on this branch: autosave quit, immediate app quit, and SIGTERM after typing all reopened with the new marker persisted to disk
