### PR TITLE
[codex] bump Aegis to 0.0.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aegis",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aegis",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.150",
         "@anthropic-ai/sdk": "^0.98.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aegis",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Aegis Desktop Application",
   "author": "Your Name",
   "main": "dist-electron/electron/main.js",


### PR DESCRIPTION
## Summary
- bump Aegis package metadata to 0.0.30
- keep package.json and package-lock.json versions aligned

## Validation
- npm run check:icons
- npm run build
- npm run check:builtin-agent
- npm run dist on the main checkout for current source
- npm run build on the 0.0.30 release worktree

Note: electron-builder packaging in the temporary Git worktree reached artifact generation, then failed during update-info cleanup because app-builder-lib could not infer repository metadata from the worktree .git file. The same packaging path passed from the main checkout before the metadata-only version bump; it will be rerun from the real main checkout after merge before pushing the release tag.