### PR TITLE
[codex] fix macOS fullscreen window title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Claude Cowork</title>
+    <title>Aegis</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -483,6 +483,7 @@ function createWindow(): void {
     height: windowState.height,
     minWidth: 800,
     minHeight: 600,
+    title: 'Aegis',
     titleBarStyle: 'hidden',
     trafficLightPosition: { x: 15, y: 15 },
     ...(process.platform === 'darwin' ? { roundedCorners: true } : {}),


### PR DESCRIPTION
## Summary
- change the renderer document title from Claude Cowork to Aegis
- set the Electron BrowserWindow title to Aegis before the renderer loads

## Validation
- npm run build
- git diff --check -- index.html src/electron/main.ts
- verified dist-react/index.html contains <title>Aegis</title>