### PR TITLE
[codex] release Aegis v0.0.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aegis",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aegis",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.150",
         "@anthropic-ai/sdk": "^0.98.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aegis",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Aegis Desktop Application",
   "author": "Your Name",
   "repository": {

--- a/src/ui/components/ProjectMarkdownEditor.tsx
+++ b/src/ui/components/ProjectMarkdownEditor.tsx
@@ -65,6 +65,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
 import { copyMarkdownAsWechatHtml, type WeChatThemeId } from '../lib/wechatMarkdown';
@@ -750,6 +751,16 @@ function ToolbarButton({
   );
 }
 
+function normalizeCopiedMarkdownSource(markdown: string): string {
+  // Milkdown's serializer escapes HTML-like prompt tags and identifier
+  // underscores (for example `\<title\_rules>`). Keep those guards out of
+  // copy/export output without touching intentional escapes elsewhere.
+  return markdown.replace(
+    /\\(<\/?)([A-Za-z][A-Za-z0-9\\_-]*)(\\?>)/g,
+    (_match, open: string, name: string) => `${open}${name.replace(/\\_/g, '_')}>`
+  );
+}
+
 export function ProjectMarkdownEditor({
   value,
   cwd,
@@ -1004,12 +1015,26 @@ export function ProjectMarkdownEditor({
   }, [applyFrontmatterChange]);
 
   const handleCopyWechatHtml = useCallback(async (themeId: WeChatThemeId = 'bubblebrain') => {
-    const markdown = currentFullMarkdownRef.current ?? value;
+    const markdown = normalizeCopiedMarkdownSource(currentFullMarkdownRef.current ?? value);
     const result = await copyMarkdownAsWechatHtml(markdown, themeId);
     if (result.ok) {
-      toast.success('已复制到公众号剪贴板');
+      toast.success(
+        result.format === 'html'
+          ? '已复制到公众号剪贴板'
+          : '富文本复制不可用，已复制原始 Markdown'
+      );
     } else {
       toast.error(`复制失败: ${result.error}`);
+    }
+  }, [value]);
+
+  const handleCopyRawMarkdown = useCallback(async () => {
+    const markdown = normalizeCopiedMarkdownSource(currentFullMarkdownRef.current ?? value);
+    try {
+      await navigator.clipboard.writeText(markdown);
+      toast.success('已复制原始 Markdown');
+    } catch (error) {
+      toast.error(`复制失败: ${error instanceof Error ? error.message : String(error)}`);
     }
   }, [value]);
 
@@ -1301,6 +1326,10 @@ export function ProjectMarkdownEditor({
               </DropdownMenuItem>
               <DropdownMenuItem onSelect={() => void handleCopyWechatHtml('lapis')}>
                 <span>Lapis</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => void handleCopyRawMarkdown()}>
+                <span>原始 Markdown</span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/src/ui/lib/wechatMarkdown.ts
+++ b/src/ui/lib/wechatMarkdown.ts
@@ -32,7 +32,7 @@
  */
 
 export type WeChatCopyResult =
-  | { ok: true; html: string; bytes: number }
+  | { ok: true; html: string; bytes: number; format: 'html' | 'markdown' }
   | { ok: false; error: string };
 
 export type WeChatThemeId = 'bubblebrain' | 'lapis';
@@ -1080,9 +1080,9 @@ export function markdownToWechatHtml(
  *     fallback also writes text/html only instead of letting Chromium
  *     synthesize a text/plain flavor from a selected rich DOM range.
  *
- *  3. navigator.clipboard.writeText(html). Last-resort. Pastes the
- *     HTML string as plain text — not what the user wanted, but at
- *     least something is on the clipboard.
+ *  3. navigator.clipboard.writeText(markdown). Last-resort. This keeps
+ *     the clipboard useful as the original Markdown instead of pasting
+ *     escaped HTML markup into plain-text targets.
  */
 export async function copyMarkdownAsWechatHtml(
   markdown: string,
@@ -1101,7 +1101,7 @@ export async function copyMarkdownAsWechatHtml(
         'text/html': new Blob([clipboardHtml], { type: 'text/html' }),
       });
       await navigator.clipboard.write([item]);
-      return { ok: true, html, bytes: html.length };
+      return { ok: true, html, bytes: html.length, format: 'html' };
     }
   } catch (err) {
     void err;
@@ -1111,17 +1111,19 @@ export async function copyMarkdownAsWechatHtml(
   // clipboard.write is blocked by browser/Electron security policy.
   try {
     if (copyViaCopyEvent(clipboardHtml)) {
-      return { ok: true, html, bytes: html.length };
+      return { ok: true, html, bytes: html.length, format: 'html' };
     }
   } catch (err) {
     void err;
   }
 
-  // 3. writeText fallback (HTML written as text)
+  // 3. Plain Markdown fallback. Never write the HTML template as text; that
+  // produces visible entities such as &quot; and &amp; when pasted outside a rich
+  // editor.
   try {
     if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(html);
-      return { ok: true, html, bytes: html.length };
+      await navigator.clipboard.writeText(markdown);
+      return { ok: true, html, bytes: markdown.length, format: 'markdown' };
     }
   } catch (err) {
     void err;


### PR DESCRIPTION
## Summary

- Bump Aegis to version `0.0.32`.
- Include the markdown copy fixes for raw Markdown and WeChat themed copy.
- Preserve intentional Markdown escapes while normalizing Milkdown serializer escapes around prompt-style tags.

## Validation

- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm ci`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run check:icons`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run dist`

Local `dist` produced x64 and arm64 mac DMG/zip artifacts.