### PR TITLE
fix: send OpenCode ACP mcp servers as array

### DIFF
--- a/src/electron/libs/codex-runner.ts
+++ b/src/electron/libs/codex-runner.ts
@@ -996,7 +996,7 @@ function runAcp(options: RunnerOptions, adapter: AcpAdapter): RunnerHandle {
 
     const cwd = session.cwd || process.cwd();
     // OpenCode owns its own MCP config — don't forward Aegis's Claude MCP map.
-    const mcpServers: Record<string, unknown> = {};
+    const mcpServers: unknown[] = [];
     let sessionResult: Record<string, unknown> | undefined;
 
     if (resumeSessionId) {


### PR DESCRIPTION
## Summary
- send OpenCode persistent ACP session MCP server payload as an array
- align persistent OpenCode session/new and session/load params with the working one-shot path

## Root cause
OpenCode 1.15.13 validates `mcpServers` as an array. The persistent Aegis OpenCode ACP runner still passed an object, so `session/new` could fail with `Invalid params`.

## Validation
- `npm run transpile:electron`
- `npm run check:builtin-agent`
- `npm run check:icons`
- `npm run build`
- OpenCode ACP smoke test for `initialize` -> `session/new` with `mcpServers: []`
