### PR TITLE
fix: stabilize project markdown editor tabs

### DIFF
--- a/scripts/verify-markdown-editor.mjs
+++ b/scripts/verify-markdown-editor.mjs
@@ -89,6 +89,8 @@ Inline \\\`code\\\`, **bold**, *italic*, and ~~strike~~.
 const value = 1;
 \\\`\\\`\\\`
 
+Paragraph immediately after code preview.
+
 ![Remote](\${remoteImage})
 
 ![Local](./local-image.svg)
@@ -96,6 +98,8 @@ const value = 1;
 | Name | Value |
 | --- | --- |
 | A | 1 |
+
+Paragraph immediately after table preview.
 
 \${filler}
 
@@ -173,6 +177,25 @@ function Harness() {
       flush: () => bridgeRef.current?.flush(),
       getSaveCount: () => saveCountRef.current,
       getMainScrollTop: () => document.querySelector('.aegis-md-main')?.scrollTop || 0,
+      scrollLineIntoView: (needle) => {
+        const view = findView();
+        const main = document.querySelector('.aegis-md-main');
+        if (!view || !main) return null;
+        const text = view.state.doc.toString();
+        const pos = text.indexOf(needle);
+        if (pos < 0) return null;
+        const coords = view.coordsAtPos(pos, 1) || view.coordsAtPos(pos, -1);
+        const lineBlock = view.lineBlockAt(pos);
+        const mainRect = main.getBoundingClientRect();
+        const contentRect = view.contentDOM.getBoundingClientRect();
+        const targetTop = coords?.top ?? contentRect.top + lineBlock.top;
+        const maxScrollTop = Math.max(0, main.scrollHeight - main.clientHeight);
+        main.scrollTop = Math.min(
+          maxScrollTop,
+          Math.max(0, main.scrollTop + targetTop - mainRect.top - (main.clientHeight * 0.45))
+        );
+        return { pos, line: view.state.doc.lineAt(pos).text };
+      },
       clickFrontmatterWidget: () => {
         const widget = document.querySelector('.aegis-cm-frontmatter-widget');
         if (!widget) return null;
@@ -274,6 +297,36 @@ function Harness() {
           complete: node.complete,
           naturalWidth: node.naturalWidth,
         }));
+        const blockWidgetMetrics = Array.from(document.querySelectorAll('.aegis-cm-block-widget')).map((node) => {
+          const style = window.getComputedStyle(node);
+          const rect = node.getBoundingClientRect();
+          const sourcePos = Number(node.getAttribute('data-source-pos'));
+          let lineBlockHeight = null;
+          if (view && Number.isFinite(sourcePos)) {
+            try {
+              lineBlockHeight = view.lineBlockAt(sourcePos).height;
+            } catch {
+              lineBlockHeight = null;
+            }
+          }
+          return {
+            className: node.className,
+            marginTop: style.marginTop,
+            marginBottom: style.marginBottom,
+            height: rect.height,
+            sourcePos: Number.isFinite(sourcePos) ? sourcePos : null,
+            lineBlockHeight,
+            heightDelta: lineBlockHeight === null ? null : Math.abs(lineBlockHeight - rect.height),
+          };
+        });
+        const main = document.querySelector('.aegis-md-main');
+        const cmScroller = document.querySelector('.aegis-md-codemirror-root .cm-scroller');
+        const scrollState = {
+          mainOverflowY: main ? window.getComputedStyle(main).overflowY : '',
+          mainScrollTop: main?.scrollTop || 0,
+          cmScrollerOverflowY: cmScroller ? window.getComputedStyle(cmScroller).overflowY : '',
+          cmScrollerScrollTop: cmScroller?.scrollTop || 0,
+        };
         return {
           hasEditor: Boolean(document.querySelector('.aegis-md-codemirror-root .cm-editor')),
           oldRoots: document.querySelectorAll('.aegis-md-milkdown-root, .ProseMirror').length,
@@ -291,6 +344,8 @@ function Harness() {
           taskCount: document.querySelectorAll('.aegis-cm-task-checkbox').length,
           outlineTriggerTexts: Array.from(document.querySelectorAll('.aegis-md-outline-trigger span')).map((node) => node.textContent || ''),
           images,
+          blockWidgetMetrics,
+          scrollState,
         };
       },
     };
@@ -393,6 +448,19 @@ async function clickPoint(win, point) {
   await delay(160);
 }
 
+async function findVisibleLineClickPoint(win, needle) {
+  const scrollResult = await win.webContents.executeJavaScript(
+    \`window.__AegisMarkdownVerify.scrollLineIntoView(\${JSON.stringify(needle)})\`,
+    true
+  );
+  if (!scrollResult) return null;
+  await delay(350);
+  return win.webContents.executeJavaScript(
+    \`window.__AegisMarkdownVerify.findLineClickPoint(\${JSON.stringify(needle)})\`,
+    true
+  );
+}
+
 function withTimeout(promise, ms, message) {
   return Promise.race([
     promise,
@@ -454,6 +522,16 @@ app.whenReady().then(async () => {
     if (!paragraphClickPoint) throw new Error('Unable to find paragraph line click point.');
     await clickPoint(win, paragraphClickPoint);
     const paragraphSelectionLine = await win.webContents.executeJavaScript('window.__AegisMarkdownVerify.getSelectionLineText()', true);
+
+    const afterCodeClickPoint = await findVisibleLineClickPoint(win, 'Paragraph immediately after code preview.');
+    if (!afterCodeClickPoint) throw new Error('Unable to find after-code paragraph line click point.');
+    await clickPoint(win, afterCodeClickPoint);
+    const afterCodeSelectionLine = await win.webContents.executeJavaScript('window.__AegisMarkdownVerify.getSelectionLineText()', true);
+
+    const afterTableClickPoint = await findVisibleLineClickPoint(win, 'Paragraph immediately after table preview.');
+    if (!afterTableClickPoint) throw new Error('Unable to find after-table paragraph line click point.');
+    await clickPoint(win, afterTableClickPoint);
+    const afterTableSelectionLine = await win.webContents.executeJavaScript('window.__AegisMarkdownVerify.getSelectionLineText()', true);
 
     await win.webContents.executeJavaScript('window.__AegisMarkdownVerify.focusAfterInlineProbe()', true);
     await pressBackquote(win);
@@ -527,6 +605,10 @@ app.whenReady().then(async () => {
       headingSelectionLine,
       paragraphClickPoint,
       paragraphSelectionLine,
+      afterCodeClickPoint,
+      afterCodeSelectionLine,
+      afterTableClickPoint,
+      afterTableSelectionLine,
       outlineJumpStart,
       outlineScrollTop,
       outlineTargetPosition,
@@ -600,6 +682,10 @@ async function main() {
       headingSelectionLine,
       paragraphClickPoint,
       paragraphSelectionLine,
+      afterCodeClickPoint,
+      afterCodeSelectionLine,
+      afterTableClickPoint,
+      afterTableSelectionLine,
       outlineJumpStart,
       outlineScrollTop,
       outlineTargetPosition,
@@ -612,6 +698,35 @@ async function main() {
     } = result;
     assert(initialSnapshot.hasEditor, 'CodeMirror editor did not mount.');
     assert(initialSnapshot.oldRoots === 0, 'Old Milkdown/ProseMirror roots are still present.');
+    assert(
+      initialSnapshot.scrollState?.mainOverflowY === 'auto' || initialSnapshot.scrollState?.mainOverflowY === 'scroll',
+      `Markdown editor should use the outer main viewport as the scroll container: ${JSON.stringify(initialSnapshot.scrollState)}`
+    );
+    assert(
+      initialSnapshot.scrollState?.cmScrollerOverflowY === 'visible',
+      `CodeMirror inner scroller should not be a competing scroll container: ${JSON.stringify(initialSnapshot.scrollState)}`
+    );
+    assert(
+      (initialSnapshot.blockWidgetMetrics || []).length >= 4,
+      `Expected measured block widgets for front matter, code, images, and table: ${JSON.stringify(initialSnapshot.blockWidgetMetrics)}`
+    );
+    const blockWidgetMarginViolations = initialSnapshot.blockWidgetMetrics.filter((metric) => (
+      Number.parseFloat(metric.marginTop) !== 0 || Number.parseFloat(metric.marginBottom) !== 0
+    ));
+    assert(
+      blockWidgetMarginViolations.length === 0,
+      `Block widget roots must not use vertical margins because CodeMirror does not include them in block height maps: ${JSON.stringify(blockWidgetMarginViolations)}`
+    );
+    const blockWidgetHeightViolations = initialSnapshot.blockWidgetMetrics.filter((metric) => (
+      metric.lineBlockHeight !== null
+        && Number.isFinite(metric.heightDelta)
+        && metric.height > 0
+        && metric.heightDelta > 4
+    ));
+    assert(
+      blockWidgetHeightViolations.length === 0,
+      `CodeMirror block height map drifted from measured widget heights: ${JSON.stringify(blockWidgetHeightViolations)}`
+    );
     assert(
       initialSnapshot.frontmatterWidgetCount === 1
         && initialSnapshot.frontmatterWidgetText.includes('tags')
@@ -644,6 +759,14 @@ async function main() {
     assert(
       paragraphSelectionLine.includes('This line has'),
       `Clicking the rendered paragraph selected the wrong source line: ${JSON.stringify({ paragraphClickPoint, paragraphSelectionLine })}`
+    );
+    assert(
+      afterCodeSelectionLine.includes('Paragraph immediately after code preview.'),
+      `Clicking a line after a rendered code widget selected the wrong source line: ${JSON.stringify({ afterCodeClickPoint, afterCodeSelectionLine })}`
+    );
+    assert(
+      afterTableSelectionLine.includes('Paragraph immediately after table preview.'),
+      `Clicking a line after a rendered table widget selected the wrong source line: ${JSON.stringify({ afterTableClickPoint, afterTableSelectionLine })}`
     );
     assert(
       outlineScrollTop > outlineJumpStart.before + 100,

--- a/src/ui/components/ProjectMarkdownEditor.tsx
+++ b/src/ui/components/ProjectMarkdownEditor.tsx
@@ -160,6 +160,11 @@ type MarkdownFrontmatterBlock = {
   frontmatter: string;
 };
 
+type MeasuredMarkdownWidgetElement = HTMLElement & {
+  __aegisMarkdownResizeObserver?: ResizeObserver;
+  __aegisMarkdownWidgetDisposed?: boolean;
+};
+
 const updateListenerFacet = EditorView.updateListener;
 const markdownHeadingFlashEffect = StateEffect.define<number | null>();
 const markdownPointerSelectingEffect = StateEffect.define<boolean>();
@@ -970,7 +975,48 @@ class TaskCheckboxWidget extends WidgetType {
   }
 }
 
-class ImagePreviewWidget extends WidgetType {
+abstract class MeasuredBlockWidget extends WidgetType {
+  destroy(dom: HTMLElement) {
+    destroyMeasuredMarkdownBlock(dom);
+  }
+}
+
+function requestMarkdownWidgetMeasure(view: EditorView, element?: MeasuredMarkdownWidgetElement) {
+  if (!view.dom.isConnected || element?.__aegisMarkdownWidgetDisposed) return;
+  view.requestMeasure();
+  window.requestAnimationFrame(() => {
+    if (view.dom.isConnected && !element?.__aegisMarkdownWidgetDisposed) {
+      view.requestMeasure();
+    }
+  });
+}
+
+function createMeasuredMarkdownBlock<K extends keyof HTMLElementTagNameMap>(
+  view: EditorView,
+  tagName: K,
+  className: string,
+  sourcePos: number
+): HTMLElementTagNameMap[K] & MeasuredMarkdownWidgetElement {
+  const element = document.createElement(tagName) as HTMLElementTagNameMap[K] & MeasuredMarkdownWidgetElement;
+  element.className = `aegis-cm-block-widget ${className}`;
+  element.dataset.sourcePos = String(sourcePos);
+
+  if (typeof ResizeObserver !== 'undefined') {
+    const observer = new ResizeObserver(() => requestMarkdownWidgetMeasure(view, element));
+    observer.observe(element);
+    element.__aegisMarkdownResizeObserver = observer;
+  }
+
+  return element;
+}
+
+function destroyMeasuredMarkdownBlock(dom: HTMLElement) {
+  const element = dom as MeasuredMarkdownWidgetElement;
+  element.__aegisMarkdownWidgetDisposed = true;
+  element.__aegisMarkdownResizeObserver?.disconnect();
+}
+
+class ImagePreviewWidget extends MeasuredBlockWidget {
   constructor(
     private readonly cwd: string,
     private readonly filePath: string,
@@ -990,9 +1036,10 @@ class ImagePreviewWidget extends WidgetType {
   }
 
   toDOM(view: EditorView) {
-    const container = document.createElement('span');
-    container.className = 'aegis-cm-image-widget';
+    const container = createMeasuredMarkdownBlock(view, 'span', 'aegis-cm-image-widget', this.sourcePos);
     container.tabIndex = 0;
+
+    const requestMeasure = () => requestMarkdownWidgetMeasure(view, container);
 
     const status = document.createElement('span');
     status.className = 'aegis-cm-image-status';
@@ -1000,19 +1047,29 @@ class ImagePreviewWidget extends WidgetType {
     container.appendChild(status);
 
     const showError = (message: string) => {
+      if (container.__aegisMarkdownWidgetDisposed) return;
       container.dataset.error = 'true';
       status.textContent = message;
+      container.replaceChildren(status);
+      requestMeasure();
     };
 
     const renderImage = (src: string) => {
+      if (container.__aegisMarkdownWidgetDisposed) return;
       container.innerHTML = '';
+      delete container.dataset.error;
       const img = document.createElement('img');
       img.src = src;
       img.alt = this.alt;
       img.title = this.alt;
       img.loading = 'lazy';
+      img.addEventListener('load', requestMeasure, { once: true });
       img.addEventListener('error', () => showError('Image failed to load.'));
       container.appendChild(img);
+      requestMeasure();
+      if (img.complete) {
+        requestMeasure();
+      }
     };
 
     const trimmed = this.src.trim();
@@ -1037,7 +1094,11 @@ class ImagePreviewWidget extends WidgetType {
       }
     }
 
-    container.addEventListener('click', () => {
+    container.addEventListener('click', (event) => {
+      const target = findClosestElement(event.target);
+      if (!target?.closest('img, .aegis-cm-image-status')) return;
+      event.preventDefault();
+      event.stopPropagation();
       view.dispatch({
         selection: EditorSelection.cursor(this.sourcePos),
         effects: EditorView.scrollIntoView(this.sourcePos, { y: 'center' }),
@@ -1052,7 +1113,7 @@ class ImagePreviewWidget extends WidgetType {
   }
 }
 
-class CodeBlockPreviewWidget extends WidgetType {
+class CodeBlockPreviewWidget extends MeasuredBlockWidget {
   constructor(
     private readonly language: string,
     private readonly code: string,
@@ -1066,9 +1127,9 @@ class CodeBlockPreviewWidget extends WidgetType {
   }
 
   toDOM(view: EditorView) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'aegis-cm-code-widget';
-    wrapper.dataset.sourcePos = String(this.sourcePos);
+    const wrapper = createMeasuredMarkdownBlock(view, 'div', 'aegis-cm-code-widget', this.sourcePos);
+    const frame = document.createElement('div');
+    frame.className = 'aegis-cm-code-frame';
 
     const header = document.createElement('div');
     header.className = 'aegis-cm-code-header';
@@ -1093,16 +1154,17 @@ class CodeBlockPreviewWidget extends WidgetType {
       });
     });
     header.appendChild(button);
-    wrapper.appendChild(header);
+    frame.appendChild(header);
 
     const body = document.createElement('pre');
     body.className = 'aegis-cm-code-body';
     const code = document.createElement('code');
     code.textContent = this.code || '';
     body.appendChild(code);
-    wrapper.appendChild(body);
+    frame.appendChild(body);
+    wrapper.appendChild(frame);
 
-    wrapper.addEventListener('click', () => {
+    frame.addEventListener('click', () => {
       view.dispatch({
         selection: EditorSelection.cursor(this.sourcePos),
         effects: EditorView.scrollIntoView(this.sourcePos, { y: 'center' }),
@@ -1117,7 +1179,7 @@ class CodeBlockPreviewWidget extends WidgetType {
   }
 }
 
-class TablePreviewWidget extends WidgetType {
+class TablePreviewWidget extends MeasuredBlockWidget {
   constructor(
     private readonly rows: string[][],
     private readonly sourcePos: number
@@ -1130,8 +1192,7 @@ class TablePreviewWidget extends WidgetType {
   }
 
   toDOM(view: EditorView) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'aegis-cm-table-widget';
+    const wrapper = createMeasuredMarkdownBlock(view, 'div', 'aegis-cm-table-widget', this.sourcePos);
     const table = document.createElement('table');
     this.rows.forEach((row, rowIndex) => {
       const tr = document.createElement('tr');
@@ -1143,7 +1204,7 @@ class TablePreviewWidget extends WidgetType {
       table.appendChild(tr);
     });
     wrapper.appendChild(table);
-    wrapper.addEventListener('click', () => {
+    table.addEventListener('click', () => {
       view.dispatch({
         selection: EditorSelection.cursor(this.sourcePos),
         effects: EditorView.scrollIntoView(this.sourcePos, { y: 'center' }),
@@ -1158,7 +1219,7 @@ class TablePreviewWidget extends WidgetType {
   }
 }
 
-class FrontmatterPreviewWidget extends WidgetType {
+class FrontmatterPreviewWidget extends MeasuredBlockWidget {
   private readonly fields: MarkdownMetadataField[];
 
   constructor(
@@ -1174,8 +1235,12 @@ class FrontmatterPreviewWidget extends WidgetType {
   }
 
   toDOM(view: EditorView) {
-    const section = document.createElement('section');
-    section.className = 'aegis-mdx-metadata-card aegis-md-editor-metadata aegis-cm-frontmatter-widget';
+    const section = createMeasuredMarkdownBlock(
+      view,
+      'section',
+      'aegis-mdx-metadata-card aegis-md-editor-metadata aegis-cm-frontmatter-widget',
+      this.editPos
+    );
     section.setAttribute('aria-label', 'Metadata');
 
     const title = document.createElement('div');
@@ -2175,7 +2240,7 @@ export function ProjectMarkdownEditor({
       EditorState.tabSize.of(2),
       EditorView.theme({
         '&': { height: '100%' },
-        '.cm-scroller': { overflow: 'auto' },
+        '.cm-scroller': { overflow: 'visible' },
       }),
     ];
 

--- a/src/ui/components/ProjectMarkdownEditor.tsx
+++ b/src/ui/components/ProjectMarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EditorSelection, EditorState, StateEffect, StateField, Transaction, type Extension } from '@codemirror/state';
 import {
   Decoration,
@@ -22,45 +22,13 @@ import {
   defaultKeymap,
   history,
   historyKeymap,
-  redo,
-  undo,
 } from '@codemirror/commands';
 import {
-  Bold,
-  CheckSquare,
-  ChevronDown,
   ChevronUp,
-  Code,
-  Heading1,
-  Heading2,
-  Heading3,
-  Image as ImageIcon,
-  Italic,
-  Link,
-  List,
-  ListOrdered,
   Plus,
-  Quote,
-  Redo2,
-  Strikethrough,
-  Table,
-  Undo2,
   X,
 } from './icons';
 import { toast } from 'sonner';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from './ui/dropdown-menu';
-import {
-  copyMarkdownAsWechatAiHtml,
-  copyMarkdownAsWechatHtml,
-  type WeChatAiThemeId,
-  type WeChatStaticThemeId,
-} from '../lib/wechatMarkdown';
 
 export type MarkdownOutlineItem = {
   id: string;
@@ -94,7 +62,6 @@ type ProjectMarkdownEditorProps = {
   fileName: string;
   hideTitleBar?: boolean;
   windowControlsInset?: boolean;
-  toolbarActions?: ReactNode;
   saveState: SaveState;
   saveError: string | null;
   onChange: (next: string) => void;
@@ -105,6 +72,14 @@ type ProjectMarkdownEditorProps = {
 export type ProjectMarkdownEditorBridge = {
   flush: () => void;
   isComposing: () => boolean;
+  getViewState: () => ProjectEditorViewState | null;
+  restoreViewState: (state: ProjectEditorViewState | null | undefined) => void;
+};
+
+export type ProjectEditorViewState = {
+  selectionFrom: number;
+  selectionTo: number;
+  scrollTop: number;
 };
 
 type PendingLocalMarkdownValue = {
@@ -1871,37 +1846,6 @@ function deriveToolbarState(view: EditorView | null): MarkdownToolbarState {
   };
 }
 
-function ToolbarButton({
-  title,
-  active = false,
-  disabled = false,
-  onClick,
-  children,
-}: {
-  title: string;
-  active?: boolean;
-  disabled?: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      className={`aegis-md-toolbar-button no-drag${active ? ' active' : ''}`}
-      title={title}
-      aria-label={title}
-      aria-pressed={active}
-      disabled={disabled}
-      onMouseDown={(event) => {
-        event.preventDefault();
-        if (!disabled) onClick();
-      }}
-    >
-      {children}
-    </button>
-  );
-}
-
 export function ProjectMarkdownEditor({
   value,
   cwd,
@@ -1909,7 +1853,6 @@ export function ProjectMarkdownEditor({
   fileName,
   hideTitleBar = false,
   windowControlsInset = false,
-  toolbarActions,
   saveState,
   saveError,
   onChange,
@@ -1932,7 +1875,6 @@ export function ProjectMarkdownEditor({
   const [outlineOpen, setOutlineOpen] = useState(false);
   const [editorFocused, setEditorFocused] = useState(false);
   const [active, setActive] = useState<MarkdownToolbarState>(EMPTY_TOOLBAR_STATE);
-  const [wechatAiGeneratingTheme, setWechatAiGeneratingTheme] = useState<WeChatAiThemeId | null>(null);
   const breadcrumb = useMemo(() => formatBreadcrumb(cwd, filePath), [cwd, filePath]);
 
   useEffect(() => {
@@ -2008,10 +1950,44 @@ export function ProjectMarkdownEditor({
 
   const isComposing = useCallback(() => composingInputRef.current, []);
 
+  const getViewState = useCallback((): ProjectEditorViewState | null => {
+    const view = viewRef.current;
+    if (!view) return null;
+    const selection = view.state.selection.main;
+    const scroller = hostRef.current?.closest<HTMLElement>('.aegis-md-main');
+    return {
+      selectionFrom: selection.from,
+      selectionTo: selection.to,
+      scrollTop: scroller?.scrollTop || 0,
+    };
+  }, []);
+
+  const restoreViewState = useCallback((state: ProjectEditorViewState | null | undefined) => {
+    const view = viewRef.current;
+    if (!view || !state) return;
+    const selectionFrom = Math.max(0, Math.min(state.selectionFrom, view.state.doc.length));
+    const selectionTo = Math.max(selectionFrom, Math.min(state.selectionTo, view.state.doc.length));
+    view.dispatch({
+      selection: EditorSelection.range(selectionFrom, selectionTo),
+    });
+    window.requestAnimationFrame(() => {
+      const scroller = hostRef.current?.closest<HTMLElement>('.aegis-md-main');
+      if (scroller) {
+        scroller.scrollTop = Math.max(0, state.scrollTop);
+      }
+      view.requestMeasure();
+    });
+  }, []);
+
   useEffect(() => {
-    onRegisterBridge?.({ flush: flushPendingMarkdownToParent, isComposing });
+    onRegisterBridge?.({
+      flush: flushPendingMarkdownToParent,
+      isComposing,
+      getViewState,
+      restoreViewState,
+    });
     return () => onRegisterBridge?.(null);
-  }, [flushPendingMarkdownToParent, isComposing, onRegisterBridge]);
+  }, [flushPendingMarkdownToParent, getViewState, isComposing, onRegisterBridge, restoreViewState]);
 
   const openOutline = useCallback(() => {
     if (outlineCloseTimerRef.current) {
@@ -2029,10 +2005,6 @@ export function ProjectMarkdownEditor({
       setOutlineOpen(false);
       outlineCloseTimerRef.current = null;
     }, 180);
-  }, []);
-
-  const focusEditor = useCallback(() => {
-    viewRef.current?.focus();
   }, []);
 
   const applyFullMarkdownChange = useCallback((next: string) => {
@@ -2075,82 +2047,6 @@ export function ProjectMarkdownEditor({
       headingFlashTimerRef.current = null;
     }, 1100);
   }, []);
-
-  const insertImage = useCallback(async () => {
-    const view = viewRef.current;
-    if (!view) return;
-    const result = await window.electron.selectMarkdownImageAsset?.(cwd, filePath);
-    if (!result?.ok || !result.relativePath) return;
-    insertImageMarkdown(view, result.relativePath, result.name || 'Image');
-  }, [cwd, filePath]);
-
-  const promptLink = useCallback(() => {
-    const view = viewRef.current;
-    if (!view) return;
-    const href = window.prompt('Link URL');
-    if (!href) return;
-    insertLink(view, href);
-  }, []);
-
-  const showWechatCopyResult = useCallback((
-    result: Awaited<ReturnType<typeof copyMarkdownAsWechatHtml>>,
-    toastId?: string | number,
-  ) => {
-    const modelDescription = result.ok && result.model
-      ? `使用：${result.runtime || 'aegis'} · ${result.model}`
-      : undefined;
-    const resultToastOptions = {
-      closeButton: true,
-      dismissible: true,
-      ...(modelDescription ? { description: modelDescription } : {}),
-    };
-    const toastOptions = toastId === undefined
-      ? resultToastOptions
-      : { ...resultToastOptions, id: toastId };
-    if (result.ok) {
-      if (result.format === 'html') {
-        toast.success('已复制到公众号剪贴板', toastOptions);
-      } else if (result.format === 'source-html') {
-        toast.success('富文本复制不可用，已复制生成的 HTML 源码', toastOptions);
-      } else {
-        toast.success('富文本复制不可用，已复制原始 Markdown', toastOptions);
-      }
-    } else {
-      toast.error(`复制失败: ${result.error}`, toastOptions);
-    }
-  }, []);
-
-  const handleCopyWechatHtml = useCallback(async (themeId: WeChatStaticThemeId = 'bubblebrain') => {
-    const markdown = viewRef.current?.state.doc.toString() ?? currentFullMarkdownRef.current ?? value;
-    const result = await copyMarkdownAsWechatHtml(markdown, themeId);
-    showWechatCopyResult(result);
-  }, [showWechatCopyResult, value]);
-
-  const handleCopyAiWechatHtml = useCallback(async (
-    themeId: WeChatAiThemeId,
-    themeLabel: string,
-  ) => {
-    if (wechatAiGeneratingTheme) return;
-    const markdown = viewRef.current?.state.doc.toString() ?? currentFullMarkdownRef.current ?? value;
-    setWechatAiGeneratingTheme(themeId);
-    const loadingToastId = toast.loading(`正在生成${themeLabel} HTML...`, {
-      description: '生成完成后会自动复制到公众号剪贴板',
-      duration: Infinity,
-      dismissible: false,
-    });
-    try {
-      const result = await copyMarkdownAsWechatAiHtml(markdown, themeId, filePath);
-      showWechatCopyResult(result, loadingToastId);
-    } catch (error) {
-      toast.error(`复制失败: ${error instanceof Error ? error.message : String(error)}`, {
-        id: loadingToastId,
-        closeButton: true,
-        dismissible: true,
-      });
-    } finally {
-      setWechatAiGeneratingTheme(null);
-    }
-  }, [filePath, showWechatCopyResult, value, wechatAiGeneratingTheme]);
 
   useEffect(() => {
     const root = hostRef.current;
@@ -2346,112 +2242,6 @@ export function ProjectMarkdownEditor({
           </div>
         </div>
       )}
-
-      <div className="aegis-md-toolbar drag-region" aria-label="Markdown formatting toolbar">
-        <div className="aegis-md-toolbar-tools">
-          <ToolbarButton title="Undo" onClick={() => { const view = viewRef.current; if (view) undo(view); focusEditor(); }}>
-            <Undo2 className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Redo" onClick={() => { const view = viewRef.current; if (view) redo(view); focusEditor(); }}>
-            <Redo2 className="h-4 w-4" />
-          </ToolbarButton>
-          <span className="aegis-md-toolbar-separator" />
-          <ToolbarButton title="Bold" active={toolbarActive.strong} onClick={() => { const view = viewRef.current; if (view) toggleInlineWrap(view, '**', '**', 'bold'); }}>
-            <Bold className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Italic" active={toolbarActive.emphasis} onClick={() => { const view = viewRef.current; if (view) toggleInlineWrap(view, '*', '*', 'italic'); }}>
-            <Italic className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Strikethrough" active={toolbarActive.strike} onClick={() => { const view = viewRef.current; if (view) toggleInlineWrap(view, '~~', '~~', 'text'); }}>
-            <Strikethrough className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Inline code" active={toolbarActive.inlineCode} onClick={() => { const view = viewRef.current; if (view) toggleInlineWrap(view, '`', '`', 'code'); }}>
-            <Code className="h-4 w-4" />
-          </ToolbarButton>
-          <span className="aegis-md-toolbar-separator" />
-          <ToolbarButton title="Heading 1" active={toolbarActive.h1} onClick={() => { const view = viewRef.current; if (view) toggleHeading(view, 1); }}>
-            <Heading1 className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Heading 2" active={toolbarActive.h2} onClick={() => { const view = viewRef.current; if (view) toggleHeading(view, 2); }}>
-            <Heading2 className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Heading 3" active={toolbarActive.h3} onClick={() => { const view = viewRef.current; if (view) toggleHeading(view, 3); }}>
-            <Heading3 className="h-4 w-4" />
-          </ToolbarButton>
-          <span className="aegis-md-toolbar-separator" />
-          <ToolbarButton title="Bullet list" active={toolbarActive.bullet} onClick={() => { const view = viewRef.current; if (view) toggleLinePrefix(view, 'bullet'); }}>
-            <List className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Numbered list" active={toolbarActive.ordered} onClick={() => { const view = viewRef.current; if (view) toggleLinePrefix(view, 'ordered'); }}>
-            <ListOrdered className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Task list" active={toolbarActive.task} onClick={() => { const view = viewRef.current; if (view) toggleLinePrefix(view, 'task'); }}>
-            <CheckSquare className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Quote" active={toolbarActive.quote} onClick={() => { const view = viewRef.current; if (view) toggleLinePrefix(view, 'quote'); }}>
-            <Quote className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Code block" active={toolbarActive.codeBlock} onClick={() => { const view = viewRef.current; if (view) insertCodeBlock(view); }}>
-            <Code className="h-4 w-4" />
-          </ToolbarButton>
-          <span className="aegis-md-toolbar-separator" />
-          <ToolbarButton title="Table" onClick={() => { const view = viewRef.current; if (view) insertTable(view); }}>
-            <Table className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Link" onClick={promptLink}>
-            <Link className="h-4 w-4" />
-          </ToolbarButton>
-          <ToolbarButton title="Image" onClick={() => void insertImage()}>
-            <ImageIcon className="h-4 w-4" />
-          </ToolbarButton>
-        </div>
-        <div className="aegis-md-toolbar-actions no-drag">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="aegis-md-toolbar-button aegis-md-toolbar-button--text"
-                title="公众号主题"
-                aria-label="公众号主题"
-                data-testid="aegis-md-toolbar-more"
-              >
-                <span className="aegis-md-toolbar-button-text-label">公众号主题</span>
-                <ChevronDown size={14} aria-hidden="true" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" sideOffset={6}>
-              <DropdownMenuItem onSelect={() => void handleCopyWechatHtml('bubblebrain')}>
-                <span>BubbleBrain</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => void handleCopyWechatHtml('lapis')}>
-                <span>Lapis</span>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                disabled={wechatAiGeneratingTheme !== null}
-                onSelect={() => void handleCopyAiWechatHtml('black-red-imprint', '黑红刊刻风')}
-              >
-                <span>
-                  {wechatAiGeneratingTheme === 'black-red-imprint'
-                    ? '黑红刊刻风生成中...'
-                    : '黑红刊刻风（AI）'}
-                </span>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                disabled={wechatAiGeneratingTheme !== null}
-                onSelect={() => void handleCopyAiWechatHtml('black-orange-imprint', '黑橙刊刻风')}
-              >
-                <span>
-                  {wechatAiGeneratingTheme === 'black-orange-imprint'
-                    ? '黑橙刊刻风生成中...'
-                    : '黑橙刊刻风（AI）'}
-                </span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {toolbarActions}
-        </div>
-      </div>
 
       {saveState === 'error' && saveError && (
         <div className="aegis-md-error">{saveError}</div>

--- a/src/ui/components/ProjectTextEditor.tsx
+++ b/src/ui/components/ProjectTextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { EditorState, EditorSelection, Transaction } from '@codemirror/state';
 import {
   EditorView,
@@ -23,6 +23,23 @@ interface ProjectTextEditorProps {
   onSave?: () => void;
   className?: string;
   revealTarget?: { line: number; token: number } | null;
+}
+
+export interface ProjectTextEditorHandle {
+  /** Force a content flush; in plain-text source mode the doc is the source, so this is a no-op kept for API parity. */
+  flush: () => void;
+  /** Whether an IME composition is currently active in the editor. */
+  isComposing: () => boolean;
+  /** Capture enough view state to restore source editing after a file tab switch. */
+  getViewState: () => ProjectTextEditorViewState | null;
+  /** Restore source selection and scroll position after remounting the editor. */
+  restoreViewState: (state: ProjectTextEditorViewState | null | undefined) => void;
+}
+
+export interface ProjectTextEditorViewState {
+  selectionFrom: number;
+  selectionTo: number;
+  scrollTop: number;
 }
 
 // Minimal undo/redo stack since @codemirror/commands is not a dependency
@@ -66,18 +83,49 @@ class UndoManager {
   }
 }
 
-export const ProjectTextEditor: React.FC<ProjectTextEditorProps> = ({
+export const ProjectTextEditor = forwardRef<ProjectTextEditorHandle, ProjectTextEditorProps>(function ProjectTextEditor({
   value,
   onChange,
   onSave,
   className,
   revealTarget,
-}) => {
+}, ref) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
   const onSaveRef = useRef(onSave);
   const isInternalChangeRef = useRef(false);
+  const composingRef = useRef(false);
+
+  useImperativeHandle(ref, () => ({
+    flush: () => {
+      // Source mode: the CodeMirror doc is the source string. No serialization,
+      // so flush is a no-op kept for API parity with markdown editors.
+    },
+    isComposing: () => composingRef.current,
+    getViewState: () => {
+      const view = viewRef.current;
+      if (!view) return null;
+      const selection = view.state.selection.main;
+      return {
+        selectionFrom: selection.from,
+        selectionTo: selection.to,
+        scrollTop: view.scrollDOM.scrollTop,
+      };
+    },
+    restoreViewState: (state) => {
+      const view = viewRef.current;
+      if (!view || !state) return;
+      const selectionFrom = Math.max(0, Math.min(state.selectionFrom, view.state.doc.length));
+      const selectionTo = Math.max(selectionFrom, Math.min(state.selectionTo, view.state.doc.length));
+      view.dispatch({
+        selection: EditorSelection.range(selectionFrom, selectionTo),
+      });
+      window.requestAnimationFrame(() => {
+        view.scrollDOM.scrollTop = Math.max(0, state.scrollTop);
+      });
+    },
+  }), []);
   const undoManagerRef = useRef(new UndoManager());
 
   useEffect(() => {
@@ -308,6 +356,8 @@ export const ProjectTextEditor: React.FC<ProjectTextEditorProps> = ({
     <div
       ref={containerRef}
       className={`aegis-text-codemirror-host h-full ${className ?? ''}`}
+      onCompositionStart={() => { composingRef.current = true; }}
+      onCompositionEnd={() => { composingRef.current = false; }}
     />
   );
-};
+});

--- a/src/ui/components/ProjectTreePanel.tsx
+++ b/src/ui/components/ProjectTreePanel.tsx
@@ -159,6 +159,8 @@ type OpenProjectFileTab = {
   name: string;
   ext: string;
   kind: 'markdown' | 'text';
+  preview: EditableProjectFilePreview;
+  draftText: string;
   viewMode: ViewMode;
   viewState: ProjectEditorViewState | null;
 };
@@ -605,6 +607,7 @@ export function ProjectTreePanel({
   const [selectedFileCwd, setSelectedFileCwd] = useState<string | null>(null);
   const [selectedPreview, setSelectedPreview] = useState<ProjectFilePreview | null>(null);
   const [openFileTabs, setOpenFileTabs] = useState<OpenProjectFileTab[]>([]);
+  const openFileTabsRef = useRef<OpenProjectFileTab[]>([]);
   const [pptxSlideIndex, setPptxSlideIndex] = useState(0);
   const [viewMode, setViewMode] = useState<ViewMode>('view');
   const [mdxRevealTarget, setMdxRevealTarget] = useState<{ line: number; token: number } | null>(null);
@@ -647,6 +650,13 @@ export function ProjectTreePanel({
   const saveAgainAfterInFlightRef = useRef(false);
   const savePromiseRef = useRef<Promise<boolean> | null>(null);
   const projectEditorFlushRef = useRef<() => Promise<ProjectEditorFlushResult>>(async () => ({ ok: true }));
+  const updateOpenFileTabs = useCallback((updater: (current: OpenProjectFileTab[]) => OpenProjectFileTab[]) => {
+    setOpenFileTabs((current) => {
+      const next = updater(current);
+      openFileTabsRef.current = next;
+      return next;
+    });
+  }, []);
   const setDraftTextSynced = useCallback((next: string) => {
     draftTextRef.current = next;
     if (saveInFlightRef.current) {
@@ -680,8 +690,18 @@ export function ProjectTreePanel({
     (next: string) => {
       setDraftTextSynced(next);
       mirrorProjectEditorDraftSync(next);
+      if (selectedFileCwd && selectedFilePath) {
+        const tabId = getProjectFileTabId(selectedFileCwd, selectedFilePath);
+        updateOpenFileTabs((current) =>
+          current.map((tab) =>
+            tab.id === tabId
+              ? { ...tab, draftText: next }
+              : tab
+          )
+        );
+      }
     },
-    [mirrorProjectEditorDraftSync, setDraftTextSynced]
+    [mirrorProjectEditorDraftSync, selectedFileCwd, selectedFilePath, setDraftTextSynced, updateOpenFileTabs]
   );
   const setSaveStateSynced = useCallback((next: 'idle' | 'saving' | 'saved' | 'error') => {
     saveStateRef.current = next;
@@ -721,8 +741,19 @@ export function ProjectTreePanel({
   const activeFileTabId = selectedFileCwd && selectedFilePath
     ? getProjectFileTabId(selectedFileCwd, selectedFilePath)
     : null;
+  const activeFileTabIdRef = useRef<string | null>(null);
+  const tabRefreshSequenceRef = useRef(0);
+  const tabRefreshTokensRef = useRef<Map<string, number>>(new Map());
   const shouldWatchProjectTree = !collapsed && activeTab === 'files';
   const shouldRefreshChangeRecords = !collapsed && activeTab === 'changes';
+
+  useEffect(() => {
+    openFileTabsRef.current = openFileTabs;
+  }, [openFileTabs]);
+
+  useEffect(() => {
+    activeFileTabIdRef.current = activeFileTabId;
+  }, [activeFileTabId]);
 
   const captureActiveEditorViewState = useCallback(() => {
     if (!activeFileTabId) return;
@@ -730,14 +761,14 @@ export function ProjectTreePanel({
       activeMarkdownBridgeRef.current?.getViewState() ||
       activeTextEditorBridgeRef.current?.getViewState() ||
       null;
-    setOpenFileTabs((current) =>
+    updateOpenFileTabs((current) =>
       current.map((tab) =>
         tab.id === activeFileTabId
           ? { ...tab, viewMode, viewState }
           : tab
       )
     );
-  }, [activeFileTabId, viewMode]);
+  }, [activeFileTabId, updateOpenFileTabs, viewMode]);
 
   const prepareActiveFileForTransition = useCallback(async () => {
     captureActiveEditorViewState();
@@ -749,14 +780,38 @@ export function ProjectTreePanel({
     return true;
   }, [captureActiveEditorViewState]);
 
+  const expandParentsForPath = useCallback((path: string) => {
+    const parts = path.split('/').filter(Boolean);
+    if (parts.length <= 1) return;
+
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      let current = '';
+      for (const part of parts.slice(0, -1)) {
+        current = current ? `${current}/${part}` : part;
+        next.add(current);
+      }
+      return next;
+    });
+  }, []);
+
+  const expandPath = useCallback((path: string) => {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      next.add(path);
+      return next;
+    });
+  }, []);
+
   const ensureOpenFileTab = useCallback((
     preview: EditableProjectFilePreview,
     fileCwd: string,
     filePath: string,
-    nextViewMode: ViewMode
+    nextViewMode: ViewMode,
+    nextDraftText = preview.text
   ) => {
     const id = getProjectFileTabId(fileCwd, filePath);
-    setOpenFileTabs((current) => {
+    updateOpenFileTabs((current) => {
       const existing = current.find((tab) => tab.id === id);
       if (existing) {
         return current.map((tab) =>
@@ -766,6 +821,8 @@ export function ProjectTreePanel({
                 name: preview.name,
                 ext: preview.ext,
                 kind: preview.kind,
+                preview,
+                draftText: nextDraftText,
                 viewMode: tab.viewMode || nextViewMode,
               }
             : tab
@@ -780,12 +837,102 @@ export function ProjectTreePanel({
           name: preview.name,
           ext: preview.ext,
           kind: preview.kind,
+          preview,
+          draftText: nextDraftText,
           viewMode: nextViewMode,
           viewState: null,
         },
       ];
     });
-  }, []);
+  }, [updateOpenFileTabs]);
+
+  const applyCachedFileTab = useCallback((tab: OpenProjectFileTab) => {
+    previewRequestIdRef.current += 1;
+    selectedEditableTextPreviewRef.current = tab.preview;
+    rememberDiskContent(tab.preview.text);
+    setSelectedFilePath(tab.filePath);
+    setSelectedFileCwd(tab.cwd);
+    expandParentsForPath(tab.filePath);
+    setViewMode(tab.viewMode);
+    setMdxRevealTarget(null);
+    setPreviewLoading(false);
+    setSelectedPreview(tab.preview);
+    setDraftTextSynced(tab.draftText);
+    setSaveStateSynced('idle');
+    setSaveErrorSynced(null);
+    setPptxSlideIndex(0);
+  }, [
+    expandParentsForPath,
+    rememberDiskContent,
+    setDraftTextSynced,
+    setSaveErrorSynced,
+    setSaveStateSynced,
+  ]);
+
+  const refreshFileTabFromDisk = useCallback(async (tabId: string) => {
+    const tab = openFileTabsRef.current.find((item) => item.id === tabId);
+    const reader = window.electron.readProjectFilePreview;
+    if (!tab || typeof reader !== 'function') return;
+
+    const refreshToken = (tabRefreshSequenceRef.current += 1);
+    tabRefreshTokensRef.current.set(tabId, refreshToken);
+
+    try {
+      const preview = (await reader(tab.cwd, tab.filePath)) as ProjectFilePreview;
+      if (tabRefreshTokensRef.current.get(tabId) !== refreshToken) return;
+      if (!isEditableProjectFilePreview(preview)) return;
+
+      const latestTab = openFileTabsRef.current.find((item) => item.id === tabId);
+      if (!latestTab) return;
+      if (latestTab.draftText !== latestTab.preview.text) return;
+
+      const changed =
+        preview.text !== latestTab.preview.text ||
+        preview.mtimeMs !== latestTab.preview.mtimeMs ||
+        preview.size !== latestTab.preview.size ||
+        preview.name !== latestTab.name ||
+        preview.ext !== latestTab.ext ||
+        preview.kind !== latestTab.kind;
+      if (!changed) return;
+
+      updateOpenFileTabs((current) =>
+        current.map((item) => {
+          if (item.id !== tabId || item.draftText !== item.preview.text) {
+            return item;
+          }
+          return {
+            ...item,
+            name: preview.name,
+            ext: preview.ext,
+            kind: preview.kind,
+            preview,
+            draftText: preview.text,
+          };
+        })
+      );
+
+      if (activeFileTabIdRef.current === tabId && draftTextRef.current === latestTab.preview.text) {
+        selectedEditableTextPreviewRef.current = preview;
+        rememberDiskContent(preview.text);
+        setSelectedPreview(preview);
+        setDraftTextSynced(preview.text);
+        setSaveStateSynced('idle');
+        setSaveErrorSynced(null);
+      }
+    } catch {
+      // Cached tabs stay usable if a background freshness check fails.
+    } finally {
+      if (tabRefreshTokensRef.current.get(tabId) === refreshToken) {
+        tabRefreshTokensRef.current.delete(tabId);
+      }
+    }
+  }, [
+    rememberDiskContent,
+    setDraftTextSynced,
+    setSaveErrorSynced,
+    setSaveStateSynced,
+    updateOpenFileTabs,
+  ]);
 
   const loadChangeRecords = async () => {
     if (!cwd) return;
@@ -1009,7 +1156,7 @@ export function ProjectTreePanel({
     setSelectedFilePath(null);
     setSelectedFileCwd(null);
     setSelectedPreview(null);
-    setOpenFileTabs([]);
+    updateOpenFileTabs(() => []);
     setViewMode('view');
     setMdxRevealTarget(null);
     setPreviewLoading(false);
@@ -1027,7 +1174,7 @@ export function ProjectTreePanel({
     setChangeRecords([]);
     setChangesError(null);
     setExpandedChangeId(null);
-  }, [cwd, setDraftTextSynced, setSaveStateSynced]);
+  }, [cwd, setDraftTextSynced, setSaveStateSynced, updateOpenFileTabs]);
 
   useEffect(() => {
     setPanelWidth((current) =>
@@ -1050,29 +1197,6 @@ export function ProjectTreePanel({
       } else {
         next.add(path);
       }
-      return next;
-    });
-  }, []);
-
-  const expandParentsForPath = useCallback((path: string) => {
-    const parts = path.split('/').filter(Boolean);
-    if (parts.length <= 1) return;
-
-    setExpandedPaths((prev) => {
-      const next = new Set(prev);
-      let current = '';
-      for (const part of parts.slice(0, -1)) {
-        current = current ? `${current}/${part}` : part;
-        next.add(current);
-      }
-      return next;
-    });
-  }, []);
-
-  const expandPath = useCallback((path: string) => {
-    setExpandedPaths((prev) => {
-      const next = new Set(prev);
-      next.add(path);
       return next;
     });
   }, []);
@@ -1159,6 +1283,15 @@ export function ProjectTreePanel({
       return;
     }
 
+    const cachedTab = openFileTabsRef.current.find((tab) =>
+      tab.id === getProjectFileTabId(cwd, filePath)
+    );
+    if (cachedTab) {
+      applyCachedFileTab(cachedTab);
+      void refreshFileTabFromDisk(cachedTab.id);
+      return;
+    }
+
     setSelectedFilePath(filePath);
     setSelectedFileCwd(cwd);
     expandParentsForPath(filePath);
@@ -1220,10 +1353,12 @@ export function ProjectTreePanel({
     }
   }, [
     activeSessionId,
+    applyCachedFileTab,
     cwd,
     expandParentsForPath,
     ensureOpenFileTab,
     prepareActiveFileForTransition,
+    refreshFileTabFromDisk,
     selectedFilePath,
     setBrowserPanelOpen,
     setProjectTreeCollapsed,
@@ -1240,9 +1375,15 @@ export function ProjectTreePanel({
     if (tab.id === activeFileTabId) return;
     const ready = await prepareActiveFileForTransition();
     if (!ready) return;
-    await selectFilePath(tab.filePath, tab.name, false, true);
-    setViewMode(tab.viewMode);
-  }, [activeFileTabId, prepareActiveFileForTransition, selectFilePath]);
+    const latestTab = openFileTabsRef.current.find((item) => item.id === tab.id) || tab;
+    applyCachedFileTab(latestTab);
+    void refreshFileTabFromDisk(latestTab.id);
+  }, [
+    activeFileTabId,
+    applyCachedFileTab,
+    prepareActiveFileForTransition,
+    refreshFileTabFromDisk,
+  ]);
 
   const canDropEntryOnParent = useCallback((entry: ProjectDraggedEntry, targetParentPath: string) => {
     if (!cwd || !entry.path || !targetParentPath) return false;
@@ -1289,24 +1430,36 @@ export function ProjectTreePanel({
 
       setProjectTree(cwd, result.tree);
       expandPath(targetParentPath);
-      setOpenFileTabs((current) =>
+      updateOpenFileTabs((current) =>
         current.map((tab) => {
           if (entry.kind === 'file' && isSameProjectPath(tab.filePath, entry.path)) {
+            const movedName = basenameOfPath(result.path!);
             return {
               ...tab,
               id: getProjectFileTabId(cwd, result.path!),
               filePath: result.path!,
-              name: basenameOfPath(result.path!),
+              name: movedName,
+              preview: {
+                ...tab.preview,
+                path: result.path!,
+                name: movedName,
+              },
             };
           }
           if (entry.kind === 'dir' && isPathInsideProjectPath(tab.filePath, entry.path)) {
             const relative = normalizeProjectPath(tab.filePath).slice(normalizeProjectPath(entry.path).length).replace(/^\/+/, '');
             const movedPath = relative ? `${result.path}/${relative}` : result.path!;
+            const movedName = basenameOfPath(movedPath);
             return {
               ...tab,
               id: getProjectFileTabId(cwd, movedPath),
               filePath: movedPath,
-              name: basenameOfPath(movedPath),
+              name: movedName,
+              preview: {
+                ...tab.preview,
+                path: movedPath,
+                name: movedName,
+              },
             };
           }
           return tab;
@@ -1315,9 +1468,10 @@ export function ProjectTreePanel({
 
       if (wasSelected) {
         const movedPath = result.path;
+        const movedName = basenameOfPath(movedPath);
         setSelectedFilePath(movedPath);
         setSelectedFileCwd(cwd);
-        setSelectedPreview((current) => current ? { ...current, path: movedPath } : current);
+        setSelectedPreview((current) => current ? { ...current, path: movedPath, name: movedName } : current);
       }
 
       toast.success(`${entry.kind === 'dir' ? 'Folder' : 'File'} moved.`);
@@ -1326,7 +1480,7 @@ export function ProjectTreePanel({
     } finally {
       setMovingProjectEntryPath(null);
     }
-  }, [canDropEntryOnParent, cwd, expandPath, selectedFilePath, setProjectTree]);
+  }, [canDropEntryOnParent, cwd, expandPath, selectedFilePath, setProjectTree, updateOpenFileTabs]);
 
   const handleProjectEntryDragStart = useCallback((event: DragEvent<HTMLDivElement>, node: ProjectTreeNode) => {
     if (node.kind !== 'file' && node.kind !== 'dir') return;
@@ -1667,7 +1821,7 @@ export function ProjectTreePanel({
     }
 
     const nextTabs = openFileTabs.filter((item) => item.id !== tabId);
-    setOpenFileTabs(nextTabs);
+    updateOpenFileTabs(() => nextTabs);
 
     if (!closingActiveTab) return;
     const closedIndex = openFileTabs.findIndex((item) => item.id === tabId);
@@ -1687,6 +1841,7 @@ export function ProjectTreePanel({
     openFileTabs,
     prepareActiveFileForTransition,
     selectFilePath,
+    updateOpenFileTabs,
   ]);
 
   const deleteEntry = useCallback(async (node: ProjectTreeNode) => {
@@ -1714,7 +1869,7 @@ export function ProjectTreePanel({
       // If the deleted file is currently being previewed, close it.
       const normalizedDeleted = normalizeProjectPath(node.path);
       const previewed = selectedFilePath ? normalizeProjectPath(selectedFilePath) : null;
-      setOpenFileTabs((current) =>
+      updateOpenFileTabs((current) =>
         current.filter((tab) => normalizeProjectPath(tab.filePath) !== normalizedDeleted)
       );
       if (previewed === normalizedDeleted) {
@@ -1724,7 +1879,7 @@ export function ProjectTreePanel({
     } catch (error) {
       toast.error(`Failed to delete: ${String(error)}`);
     }
-  }, [closePreview, cwd, selectedFilePath, setProjectTree]);
+  }, [closePreview, cwd, selectedFilePath, setProjectTree, updateOpenFileTabs]);
 
   useEffect(() => {
     const handleOpenProjectFile = (event: Event) => {
@@ -1933,14 +2088,14 @@ export function ProjectTreePanel({
 
   useEffect(() => {
     if (!activeFileTabId) return;
-    setOpenFileTabs((current) =>
+    updateOpenFileTabs((current) =>
       current.map((tab) =>
         tab.id === activeFileTabId
           ? { ...tab, viewMode }
           : tab
       )
     );
-  }, [activeFileTabId, viewMode]);
+  }, [activeFileTabId, updateOpenFileTabs, viewMode]);
 
   useEffect(() => {
     if (!activeFileTabId || previewLoading || !selectedEditableTextPreview) return;
@@ -2027,10 +2182,11 @@ export function ProjectTreePanel({
           text: textToSave,
           size: result.size ?? previewToSave.size,
           mtimeMs: result.mtimeMs ?? previewToSave.mtimeMs,
-        };
+        } as EditableProjectFilePreview;
         selectedEditableTextPreviewRef.current = savedPreview;
         rememberDiskContent(textToSave);
         setSelectedPreview(savedPreview);
+        ensureOpenFileTab(savedPreview, selectedFileCwd, selectedFilePath, viewMode, textToSave);
         void loadChangeRecords();
         savedOk = true;
         setSaveStateSynced('saved');
@@ -2068,7 +2224,7 @@ export function ProjectTreePanel({
       savePromiseRef.current = null;
     }
     return saveOk;
-  }, [selectedFileCwd, selectedFilePath, setSaveErrorSynced, setSaveStateSynced]);
+  }, [ensureOpenFileTab, selectedFileCwd, selectedFilePath, setSaveErrorSynced, setSaveStateSynced, viewMode]);
 
   useEffect(() => {
     if (
@@ -2189,15 +2345,27 @@ export function ProjectTreePanel({
         text: payload.text,
         mtimeMs: payload.mtimeMs,
         size: payload.size,
-      };
+      } as EditableProjectFilePreview;
       selectedEditableTextPreviewRef.current = latest;
       rememberDiskContent(payload.text);
       setSelectedPreview(latest);
       setDraftTextSynced(payload.text);
+      if (selectedFileCwd && selectedFilePath) {
+        ensureOpenFileTab(latest, selectedFileCwd, selectedFilePath, viewMode, payload.text);
+      }
       setSaveStateSynced('idle');
       setSaveErrorSynced(null);
     },
-    [rememberDiskContent, setDraftTextSynced, setSaveErrorSynced, setSaveStateSynced]
+    [
+      ensureOpenFileTab,
+      rememberDiskContent,
+      selectedFileCwd,
+      selectedFilePath,
+      setDraftTextSynced,
+      setSaveErrorSynced,
+      setSaveStateSynced,
+      viewMode,
+    ]
   );
 
   // Subscribe to disk changes for the open editable file. Event-driven via the
@@ -2267,9 +2435,12 @@ export function ProjectTreePanel({
             ...currentPreview,
             mtimeMs: detail.mtimeMs,
             size: detail.size,
-          };
+          } as EditableProjectFilePreview;
           selectedEditableTextPreviewRef.current = refreshed;
           setSelectedPreview(refreshed);
+          if (selectedFileCwd && selectedFilePath) {
+            ensureOpenFileTab(refreshed, selectedFileCwd, selectedFilePath, viewMode, draftTextRef.current);
+          }
         }
         return;
       }
@@ -2295,7 +2466,7 @@ export function ProjectTreePanel({
 
     window.addEventListener('aegis:project-file-changed', handleFileChanged);
     return () => window.removeEventListener('aegis:project-file-changed', handleFileChanged);
-  }, [applyExternalReload, rememberDiskContent, selectedFileCwd, selectedFilePath]);
+  }, [applyExternalReload, ensureOpenFileTab, rememberDiskContent, selectedFileCwd, selectedFilePath, viewMode]);
 
   // Apply a deferred external reload once IME composition settles.
   useEffect(() => {

--- a/src/ui/components/ProjectTreePanel.tsx
+++ b/src/ui/components/ProjectTreePanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
-import { FolderClosed, FolderOpen, ChevronLeft, ChevronRight, Copy, Check, X, RefreshCw, Maximize2, Minimize2, File, FileDiff, Files, FileAddIcon, FolderAddIcon, Trash2 } from './icons';
+import { FolderClosed, FolderOpen, ChevronDown, ChevronLeft, ChevronRight, Copy, Check, X, RefreshCw, Maximize2, Minimize2, File, FileDiff, Files, FileAddIcon, FolderAddIcon, Trash2 } from './icons';
 import { pptxToHtml } from '@jvmr/pptx-to-html';
 import { toast } from 'sonner';
 import { useAppStore } from '../store/useAppStore';
@@ -10,9 +10,22 @@ import TextFileReader from './TextFileReader';
 import { FileTypeIcon } from './FileTypeIcon';
 import { ProjectMarkdownEditor, type ProjectMarkdownEditorBridge } from './ProjectMarkdownEditor';
 import { ProjectMdxPreview, ProjectMdxProperties, parseMdxDocument } from './ProjectMdxPreview';
-import { ProjectTextEditor } from './ProjectTextEditor';
+import { ProjectTextEditor, type ProjectTextEditorHandle } from './ProjectTextEditor';
 import { IconButton } from './ui/icon-button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu';
 import { isHtmlFilePath, openHtmlFileInBrowserTab } from '../utils/html-preview';
+import {
+  copyMarkdownAsWechatAiHtml,
+  copyMarkdownAsWechatHtml,
+  type WeChatAiThemeId,
+  type WeChatStaticThemeId,
+} from '../lib/wechatMarkdown';
 import {
   applyDiffToChangeRecord,
   applyTextMetaToChangeRecord,
@@ -124,6 +137,32 @@ type ProjectFilePreview =
       message: string;
     };
 
+type EditableProjectFilePreview = {
+  kind: 'markdown' | 'text';
+  path: string;
+  name: string;
+  ext: string;
+  size: number;
+  mtimeMs: number;
+  text: string;
+  editable: true;
+};
+type ProjectEditorViewState = {
+  selectionFrom: number;
+  selectionTo: number;
+  scrollTop: number;
+};
+type OpenProjectFileTab = {
+  id: string;
+  cwd: string;
+  filePath: string;
+  name: string;
+  ext: string;
+  kind: 'markdown' | 'text';
+  viewMode: ViewMode;
+  viewState: ProjectEditorViewState | null;
+};
+
 type CreateEntryKind = 'file' | 'folder';
 type CreateDraftState = {
   id: number;
@@ -178,6 +217,18 @@ function basenameOfPath(filePath: string): string {
   const normalized = normalizeProjectPath(filePath);
   const parts = normalized.split('/').filter(Boolean);
   return parts[parts.length - 1] || normalized || 'Project';
+}
+
+function getProjectFileTabId(cwd: string, filePath: string): string {
+  return `${normalizeProjectPath(cwd)}::${normalizeProjectPath(filePath)}`;
+}
+
+function isEditableProjectFilePreview(preview: ProjectFilePreview | null): preview is EditableProjectFilePreview {
+  return (
+    !!preview &&
+    (preview.kind === 'markdown' || preview.kind === 'text') &&
+    preview.editable
+  );
 }
 
 function isSameProjectPath(left: string, right: string): boolean {
@@ -553,6 +604,7 @@ export function ProjectTreePanel({
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
   const [selectedFileCwd, setSelectedFileCwd] = useState<string | null>(null);
   const [selectedPreview, setSelectedPreview] = useState<ProjectFilePreview | null>(null);
+  const [openFileTabs, setOpenFileTabs] = useState<OpenProjectFileTab[]>([]);
   const [pptxSlideIndex, setPptxSlideIndex] = useState(0);
   const [viewMode, setViewMode] = useState<ViewMode>('view');
   const [mdxRevealTarget, setMdxRevealTarget] = useState<{ line: number; token: number } | null>(null);
@@ -567,6 +619,8 @@ export function ProjectTreePanel({
   const saveStateRef = useRef<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const selectedEditableTextPreviewRef = useRef<ProjectFilePreview | null>(null);
   const activeMarkdownBridgeRef = useRef<ProjectMarkdownEditorBridge | null>(null);
+  const activeTextEditorBridgeRef = useRef<ProjectTextEditorHandle | null>(null);
+  const [wechatAiGeneratingTheme, setWechatAiGeneratingTheme] = useState<WeChatAiThemeId | null>(null);
   // Every disk content we have loaded, saved, or applied for the open file.
   // The watcher only treats an event as a genuine external change when its
   // content is NOT in this set. A set (not a single value) is required because
@@ -640,6 +694,9 @@ export function ProjectTreePanel({
   const registerMarkdownBridge = useCallback((bridge: ProjectMarkdownEditorBridge | null) => {
     activeMarkdownBridgeRef.current = bridge;
   }, []);
+  const registerTextEditorBridge = useCallback((bridge: ProjectTextEditorHandle | null) => {
+    activeTextEditorBridgeRef.current = bridge;
+  }, []);
   const copiedTimerRef = useRef<number | null>(null);
   const [copiedPath, setCopiedPath] = useState(false);
   const createDraftIdRef = useRef(0);
@@ -661,8 +718,74 @@ export function ProjectTreePanel({
   const activeSession = activeSessionId ? sessions[activeSessionId] : null;
   const activeCwd = activeSession?.cwd || null;
   const cwd = activeCwd || projectCwd || null;
+  const activeFileTabId = selectedFileCwd && selectedFilePath
+    ? getProjectFileTabId(selectedFileCwd, selectedFilePath)
+    : null;
   const shouldWatchProjectTree = !collapsed && activeTab === 'files';
   const shouldRefreshChangeRecords = !collapsed && activeTab === 'changes';
+
+  const captureActiveEditorViewState = useCallback(() => {
+    if (!activeFileTabId) return;
+    const viewState =
+      activeMarkdownBridgeRef.current?.getViewState() ||
+      activeTextEditorBridgeRef.current?.getViewState() ||
+      null;
+    setOpenFileTabs((current) =>
+      current.map((tab) =>
+        tab.id === activeFileTabId
+          ? { ...tab, viewMode, viewState }
+          : tab
+      )
+    );
+  }, [activeFileTabId, viewMode]);
+
+  const prepareActiveFileForTransition = useCallback(async () => {
+    captureActiveEditorViewState();
+    const result = await projectEditorFlushRef.current();
+    if (!result.ok) {
+      toast.error(result.message || 'Failed to save pending editor changes.');
+      return false;
+    }
+    return true;
+  }, [captureActiveEditorViewState]);
+
+  const ensureOpenFileTab = useCallback((
+    preview: EditableProjectFilePreview,
+    fileCwd: string,
+    filePath: string,
+    nextViewMode: ViewMode
+  ) => {
+    const id = getProjectFileTabId(fileCwd, filePath);
+    setOpenFileTabs((current) => {
+      const existing = current.find((tab) => tab.id === id);
+      if (existing) {
+        return current.map((tab) =>
+          tab.id === id
+            ? {
+                ...tab,
+                name: preview.name,
+                ext: preview.ext,
+                kind: preview.kind,
+                viewMode: tab.viewMode || nextViewMode,
+              }
+            : tab
+        );
+      }
+      return [
+        ...current,
+        {
+          id,
+          cwd: fileCwd,
+          filePath,
+          name: preview.name,
+          ext: preview.ext,
+          kind: preview.kind,
+          viewMode: nextViewMode,
+          viewState: null,
+        },
+      ];
+    });
+  }, []);
 
   const loadChangeRecords = async () => {
     if (!cwd) return;
@@ -886,6 +1009,7 @@ export function ProjectTreePanel({
     setSelectedFilePath(null);
     setSelectedFileCwd(null);
     setSelectedPreview(null);
+    setOpenFileTabs([]);
     setViewMode('view');
     setMdxRevealTarget(null);
     setPreviewLoading(false);
@@ -982,16 +1106,21 @@ export function ProjectTreePanel({
     setCreateDraft((current) => current ? { ...current, name, error: null } : current);
   }, []);
 
-  const selectFilePath = useCallback(async (filePath: string, fileName?: string, toggleSame = false) => {
+  const selectFilePath = useCallback(async (
+    filePath: string,
+    fileName?: string,
+    toggleSame = false,
+    skipTransition = false
+  ) => {
     if (!cwd) return;
 
-    // Toggle: 如果点击的是已选中的文件，取消选中
+    // Tabs own closing now; clicking the active file in the tree should keep it active.
     if (toggleSame && selectedFilePath === filePath) {
-      setSelectedFilePath(null);
-      setSelectedFileCwd(null);
-      setSelectedPreview(null);
-      setMdxRevealTarget(null);
       return;
+    }
+    if (!skipTransition && selectedFilePath && selectedFilePath !== filePath) {
+      const ready = await prepareActiveFileForTransition();
+      if (!ready) return;
     }
 
     const name = fileName || filePath.split('/').filter(Boolean).pop() || filePath;
@@ -1064,10 +1193,16 @@ export function ProjectTreePanel({
       if (preview.kind === 'text' && preview.ext === '.mdx') {
         setDraftTextSynced(preview.text);
         setViewMode('code');
+        if (preview.editable) {
+          ensureOpenFileTab(preview as EditableProjectFilePreview, cwd, filePath, 'code');
+        }
         return;
       }
       if ((preview.kind === 'text' || preview.kind === 'markdown') && preview.editable) {
+        const nextViewMode = preview.kind === 'text' ? 'code' : 'view';
+        setViewMode(nextViewMode);
         setDraftTextSynced(preview.text);
+        ensureOpenFileTab(preview as EditableProjectFilePreview, cwd, filePath, nextViewMode);
       }
     } catch (error) {
       if (previewRequestIdRef.current !== requestId) return;
@@ -1087,6 +1222,8 @@ export function ProjectTreePanel({
     activeSessionId,
     cwd,
     expandParentsForPath,
+    ensureOpenFileTab,
+    prepareActiveFileForTransition,
     selectedFilePath,
     setBrowserPanelOpen,
     setProjectTreeCollapsed,
@@ -1098,6 +1235,14 @@ export function ProjectTreePanel({
     if (node.kind !== 'file') return;
     await selectFilePath(node.path, node.name, true);
   };
+
+  const activateProjectFileTab = useCallback(async (tab: OpenProjectFileTab) => {
+    if (tab.id === activeFileTabId) return;
+    const ready = await prepareActiveFileForTransition();
+    if (!ready) return;
+    await selectFilePath(tab.filePath, tab.name, false, true);
+    setViewMode(tab.viewMode);
+  }, [activeFileTabId, prepareActiveFileForTransition, selectFilePath]);
 
   const canDropEntryOnParent = useCallback((entry: ProjectDraggedEntry, targetParentPath: string) => {
     if (!cwd || !entry.path || !targetParentPath) return false;
@@ -1144,6 +1289,29 @@ export function ProjectTreePanel({
 
       setProjectTree(cwd, result.tree);
       expandPath(targetParentPath);
+      setOpenFileTabs((current) =>
+        current.map((tab) => {
+          if (entry.kind === 'file' && isSameProjectPath(tab.filePath, entry.path)) {
+            return {
+              ...tab,
+              id: getProjectFileTabId(cwd, result.path!),
+              filePath: result.path!,
+              name: basenameOfPath(result.path!),
+            };
+          }
+          if (entry.kind === 'dir' && isPathInsideProjectPath(tab.filePath, entry.path)) {
+            const relative = normalizeProjectPath(tab.filePath).slice(normalizeProjectPath(entry.path).length).replace(/^\/+/, '');
+            const movedPath = relative ? `${result.path}/${relative}` : result.path!;
+            return {
+              ...tab,
+              id: getProjectFileTabId(cwd, movedPath),
+              filePath: movedPath,
+              name: basenameOfPath(movedPath),
+            };
+          }
+          return tab;
+        })
+      );
 
       if (wasSelected) {
         const movedPath = result.path;
@@ -1377,6 +1545,10 @@ export function ProjectTreePanel({
   ) => {
     const reader = window.electron.readProjectFilePreview;
     if (typeof reader !== 'function') return;
+    if (selectedFilePath && selectedFilePath !== filePath) {
+      const ready = await prepareActiveFileForTransition();
+      if (!ready) return;
+    }
 
     const name = filePath.split('/').filter(Boolean).pop() || filePath;
     const fileCwd = dirnameOfPath(filePath);
@@ -1400,6 +1572,9 @@ export function ProjectTreePanel({
         setSelectedPreview(preview);
         setDraftTextSynced(preview.text);
         setViewMode('code'); // default to source editing like Cursor
+        if (preview.editable) {
+          ensureOpenFileTab(preview as EditableProjectFilePreview, fileCwd, filePath, 'code');
+        }
         if (typeof options.lineStart === 'number') {
           mdxRevealTokenRef.current += 1;
           setMdxRevealTarget({
@@ -1413,6 +1588,7 @@ export function ProjectTreePanel({
         setSelectedPreview(preview);
         if (preview.editable) {
           setDraftTextSynced(preview.text);
+          ensureOpenFileTab(preview as EditableProjectFilePreview, fileCwd, filePath, 'view');
         }
         return;
       }
@@ -1435,6 +1611,13 @@ export function ProjectTreePanel({
         return;
       }
       if (preview.kind === 'text' || preview.kind === 'html') {
+        if (preview.kind === 'text' && preview.editable) {
+          setSelectedPreview(preview);
+          setDraftTextSynced(preview.text);
+          setViewMode('code');
+          ensureOpenFileTab(preview as EditableProjectFilePreview, fileCwd, filePath, 'code');
+          return;
+        }
         setSelectedPreview({ ...preview, editable: false });
         return;
       }
@@ -1453,7 +1636,13 @@ export function ProjectTreePanel({
         setPreviewLoading(false);
       }
     }
-  }, [setDraftTextSynced, setSaveStateSynced]);
+  }, [
+    ensureOpenFileTab,
+    prepareActiveFileForTransition,
+    selectedFilePath,
+    setDraftTextSynced,
+    setSaveStateSynced,
+  ]);
 
   const closePreview = useCallback(() => {
     setSelectedFilePath(null);
@@ -1467,6 +1656,38 @@ export function ProjectTreePanel({
     setPptxSlideIndex(0);
     if (isFullscreen && onToggleFullscreen) onToggleFullscreen();
   }, [isFullscreen, onToggleFullscreen, setDraftTextSynced, setSaveStateSynced]);
+
+  const closeProjectFileTab = useCallback(async (tabId: string) => {
+    const tab = openFileTabs.find((item) => item.id === tabId);
+    if (!tab) return;
+    const closingActiveTab = tabId === activeFileTabId;
+    if (closingActiveTab) {
+      const ready = await prepareActiveFileForTransition();
+      if (!ready) return;
+    }
+
+    const nextTabs = openFileTabs.filter((item) => item.id !== tabId);
+    setOpenFileTabs(nextTabs);
+
+    if (!closingActiveTab) return;
+    const closedIndex = openFileTabs.findIndex((item) => item.id === tabId);
+    const nextTab =
+      nextTabs[Math.max(0, closedIndex - 1)] ||
+      nextTabs[closedIndex] ||
+      null;
+    if (nextTab) {
+      await selectFilePath(nextTab.filePath, nextTab.name, false, true);
+      setViewMode(nextTab.viewMode);
+      return;
+    }
+    closePreview();
+  }, [
+    activeFileTabId,
+    closePreview,
+    openFileTabs,
+    prepareActiveFileForTransition,
+    selectFilePath,
+  ]);
 
   const deleteEntry = useCallback(async (node: ProjectTreeNode) => {
     if (!cwd) return;
@@ -1493,6 +1714,9 @@ export function ProjectTreePanel({
       // If the deleted file is currently being previewed, close it.
       const normalizedDeleted = normalizeProjectPath(node.path);
       const previewed = selectedFilePath ? normalizeProjectPath(selectedFilePath) : null;
+      setOpenFileTabs((current) =>
+        current.filter((tab) => normalizeProjectPath(tab.filePath) !== normalizedDeleted)
+      );
       if (previewed === normalizedDeleted) {
         closePreview();
       }
@@ -1597,6 +1821,70 @@ export function ProjectTreePanel({
     }
   };
 
+  const showWechatCopyResult = useCallback((
+    result: Awaited<ReturnType<typeof copyMarkdownAsWechatHtml>>,
+    toastId?: string | number,
+  ) => {
+    const modelDescription = result.ok && result.model
+      ? `使用：${result.runtime || 'aegis'} · ${result.model}`
+      : undefined;
+    const resultToastOptions = {
+      closeButton: true,
+      dismissible: true,
+      ...(modelDescription ? { description: modelDescription } : {}),
+    };
+    const toastOptions = toastId === undefined
+      ? resultToastOptions
+      : { ...resultToastOptions, id: toastId };
+    if (result.ok) {
+      if (result.format === 'html') {
+        toast.success('已复制到公众号剪贴板', toastOptions);
+      } else if (result.format === 'source-html') {
+        toast.success('富文本复制不可用，已复制生成的 HTML 源码', toastOptions);
+      } else {
+        toast.success('富文本复制不可用，已复制原始 Markdown', toastOptions);
+      }
+    } else {
+      toast.error(`复制失败: ${result.error}`, toastOptions);
+    }
+  }, []);
+
+  const handleCopyWechatHtml = useCallback(async (themeId: WeChatStaticThemeId = 'bubblebrain') => {
+    activeMarkdownBridgeRef.current?.flush();
+    const result = await copyMarkdownAsWechatHtml(draftTextRef.current, themeId);
+    showWechatCopyResult(result);
+  }, [showWechatCopyResult]);
+
+  const handleCopyAiWechatHtml = useCallback(async (
+    themeId: WeChatAiThemeId,
+    themeLabel: string,
+  ) => {
+    if (wechatAiGeneratingTheme) return;
+    activeMarkdownBridgeRef.current?.flush();
+    setWechatAiGeneratingTheme(themeId);
+    const loadingToastId = toast.loading(`正在生成${themeLabel} HTML...`, {
+      description: '生成完成后会自动复制到公众号剪贴板',
+      duration: Infinity,
+      dismissible: false,
+    });
+    try {
+      const result = await copyMarkdownAsWechatAiHtml(
+        draftTextRef.current,
+        themeId,
+        selectedFilePath || undefined,
+      );
+      showWechatCopyResult(result, loadingToastId);
+    } catch (error) {
+      toast.error(`复制失败: ${error instanceof Error ? error.message : String(error)}`, {
+        id: loadingToastId,
+        closeButton: true,
+        dismissible: true,
+      });
+    } finally {
+      setWechatAiGeneratingTheme(null);
+    }
+  }, [selectedFilePath, showWechatCopyResult, wechatAiGeneratingTheme]);
+
   useEffect(() => {
     return () => {
       if (copiedTimerRef.current) {
@@ -1626,10 +1914,7 @@ export function ProjectTreePanel({
   }, [collapsed, selectedFilePath, previewPanelWidth]);
 
   const selectedEditableTextPreview =
-    selectedPreview &&
-    (selectedPreview.kind === 'markdown' ||
-      (selectedPreview.kind === 'text' && selectedPreview.ext === '.mdx')) &&
-    selectedPreview.editable
+    isEditableProjectFilePreview(selectedPreview)
       ? selectedPreview
       : null;
   const hasEditableTextOpen = Boolean(selectedEditableTextPreview);
@@ -1645,6 +1930,28 @@ export function ProjectTreePanel({
   useEffect(() => {
     selectedEditableTextPreviewRef.current = selectedEditableTextPreview;
   }, [selectedEditableTextPreview]);
+
+  useEffect(() => {
+    if (!activeFileTabId) return;
+    setOpenFileTabs((current) =>
+      current.map((tab) =>
+        tab.id === activeFileTabId
+          ? { ...tab, viewMode }
+          : tab
+      )
+    );
+  }, [activeFileTabId, viewMode]);
+
+  useEffect(() => {
+    if (!activeFileTabId || previewLoading || !selectedEditableTextPreview) return;
+    const tab = openFileTabs.find((item) => item.id === activeFileTabId);
+    if (!tab?.viewState) return;
+    const viewState = tab.viewState;
+    window.requestAnimationFrame(() => {
+      activeMarkdownBridgeRef.current?.restoreViewState(viewState);
+      activeTextEditorBridgeRef.current?.restoreViewState(viewState);
+    });
+  }, [activeFileTabId, openFileTabs, previewLoading, selectedEditableTextPreview]);
 
   // Mirror unsaved text to the main process for the synchronous quit fallback.
   useEffect(() => {
@@ -1673,7 +1980,6 @@ export function ProjectTreePanel({
     if (
       !previewToSave ||
       (previewToSave.kind !== 'markdown' && previewToSave.kind !== 'text') ||
-      (previewToSave.kind === 'text' && previewToSave.ext !== '.mdx') ||
       !previewToSave.editable
     ) {
       return true;
@@ -1781,6 +2087,7 @@ export function ProjectTreePanel({
 
   const flushProjectEditorBeforeClose = useCallback(async (): Promise<ProjectEditorFlushResult> => {
     activeMarkdownBridgeRef.current?.flush();
+    activeTextEditorBridgeRef.current?.flush();
     const saveOk = await handleSaveText();
     const currentPreview = selectedEditableTextPreviewRef.current;
     const stillDirty =
@@ -1819,6 +2126,7 @@ export function ProjectTreePanel({
     const getDirtyContent = (flushEditor: boolean): string | null => {
       if (flushEditor) {
         activeMarkdownBridgeRef.current?.flush();
+        activeTextEditorBridgeRef.current?.flush();
       }
       const currentPreview = selectedEditableTextPreviewRef.current;
       if (
@@ -1940,7 +2248,9 @@ export function ProjectTreePanel({
       // File removed/renamed away: keep the in-editor buffer rather than wiping it.
       if (!detail.exists) return;
 
-      const composing = activeMarkdownBridgeRef.current?.isComposing() ?? false;
+      const composing =
+        (activeMarkdownBridgeRef.current?.isComposing() ?? false) ||
+        (activeTextEditorBridgeRef.current?.isComposing() ?? false);
 
       // Seed the known-contents set on the very first event so the originally
       // loaded preview text is recognised as "ours".
@@ -1991,7 +2301,12 @@ export function ProjectTreePanel({
   useEffect(() => {
     const pending = pendingExternalReloadRef.current;
     if (!pending) return;
-    if (activeMarkdownBridgeRef.current?.isComposing()) return;
+    if (
+      activeMarkdownBridgeRef.current?.isComposing() ||
+      activeTextEditorBridgeRef.current?.isComposing()
+    ) {
+      return;
+    }
     pendingExternalReloadRef.current = null;
     if (pending.text !== draftTextRef.current) {
       applyExternalReload(pending);
@@ -2157,6 +2472,14 @@ export function ProjectTreePanel({
     isMarkdownPreviewSurface &&
     selectedPreview?.editable &&
     !!selectedFileCwd &&
+    !!selectedFilePath;
+  const activeOpenFileTab = activeFileTabId
+    ? openFileTabs.find((tab) => tab.id === activeFileTabId) || null
+    : null;
+  const showProjectFileTabs = openFileTabs.length > 0;
+  const canCopyWechat =
+    selectedPreview?.kind === 'markdown' &&
+    selectedPreview.editable &&
     !!selectedFilePath;
   const projectRootDropHoverId = visibleTree ? getNodeDropHoverId(visibleTree.path) : null;
   const isProjectRootDropTarget =
@@ -2529,8 +2852,164 @@ export function ProjectTreePanel({
               </div>
             )}
 
-            <div className={`h-full min-w-0 flex flex-col ${isEditableMarkdownPreview ? '' : 'px-3 py-3'}`}>
-              {!isEditableMarkdownPreview ? (
+            <div className={`h-full min-w-0 flex flex-col ${showProjectFileTabs || isEditableMarkdownPreview ? '' : 'px-3 py-3'}`}>
+              {showProjectFileTabs && (
+                <div
+                  className={`aegis-project-file-tabs${isFullscreen ? ' window-controls-inset' : ''} drag-region flex h-11 flex-shrink-0 items-center gap-2 border-b border-[var(--border)] bg-[var(--bg-primary)] pl-2 pr-2`}
+                >
+                  <div className="no-drag flex min-w-0 flex-1 items-end overflow-x-auto">
+                    {openFileTabs.map((tab) => {
+                      const activeTab = tab.id === activeFileTabId;
+                      const dirty = activeTab && canSaveText;
+                      return (
+                        <button
+                          key={tab.id}
+                          type="button"
+                          onClick={() => void activateProjectFileTab(tab)}
+                          className={`group flex h-9 max-w-[190px] min-w-[112px] items-center gap-1.5 rounded-t-[7px] border border-b-0 px-2.5 text-left text-xs transition-colors ${
+                            activeTab
+                              ? 'border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-primary)] shadow-[0_-1px_0_var(--bg-primary),0_1px_0_var(--bg-primary)]'
+                              : 'border-transparent bg-transparent text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)] hover:text-[var(--text-primary)]'
+                          }`}
+                          title={tab.filePath}
+                        >
+                          <FileTypeIcon name={tab.name} className="h-3.5 w-3.5 flex-shrink-0" fallbackClassName="h-3.5 w-3.5 flex-shrink-0 text-[var(--text-secondary)]" />
+                          <span className="min-w-0 flex-1 truncate">{tab.name}</span>
+                          {dirty && <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[var(--accent)]" aria-label="Unsaved changes" />}
+                          <span
+                            role="button"
+                            tabIndex={0}
+                            aria-label={`Close ${tab.name}`}
+                            className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-[4px] text-[var(--text-muted)] opacity-70 transition-opacity hover:bg-[var(--bg-tertiary)] hover:text-[var(--text-primary)] group-hover:opacity-100"
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              void closeProjectFileTab(tab.id);
+                            }}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter' || event.key === ' ') {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                void closeProjectFileTab(tab.id);
+                              }
+                            }}
+                          >
+                            <X className="h-3 w-3" aria-hidden="true" />
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  <div className="no-drag flex flex-shrink-0 items-center gap-1">
+                    {(selectedPreview?.kind === 'html' || isMdxFilePreview) && (
+                      <ViewModeToggle
+                        value={viewMode}
+                        onChange={setViewMode}
+                        options={
+                          isMdxFilePreview
+                            ? [
+                                { value: 'code', label: 'Source', title: 'Edit source' },
+                                { value: 'view', label: 'Preview', title: 'Preview MDX' },
+                                { value: 'split', label: 'Split', title: 'Source and preview' },
+                              ]
+                            : undefined
+                        }
+                      />
+                    )}
+
+                    {canSaveText && (
+                      <button
+                        onClick={() => {
+                          void handleSaveText();
+                        }}
+                        disabled={saveState === 'saving'}
+                        className="px-2 py-1 text-xs rounded-md bg-[var(--accent)] text-[var(--accent-foreground)] hover:bg-[var(--accent-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+                        title="Save"
+                      >
+                        {saveState === 'saving'
+                          ? 'Saving...'
+                          : saveState === 'saved'
+                            ? 'Saved'
+                            : 'Save'}
+                      </button>
+                    )}
+
+                    {canCopyWechat && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className="inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border)] bg-[var(--bg-primary)] px-2 text-xs text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-secondary)] hover:text-[var(--text-primary)]"
+                            title="公众号主题"
+                            aria-label="公众号主题"
+                          >
+                            <span>公众号主题</span>
+                            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" sideOffset={6}>
+                          <DropdownMenuItem onSelect={() => void handleCopyWechatHtml('bubblebrain')}>
+                            <span>BubbleBrain</span>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onSelect={() => void handleCopyWechatHtml('lapis')}>
+                            <span>Lapis</span>
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            disabled={wechatAiGeneratingTheme !== null}
+                            onSelect={() => void handleCopyAiWechatHtml('black-red-imprint', '黑红刊刻风')}
+                          >
+                            <span>
+                              {wechatAiGeneratingTheme === 'black-red-imprint'
+                                ? '黑红刊刻风生成中...'
+                                : '黑红刊刻风（AI）'}
+                            </span>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            disabled={wechatAiGeneratingTheme !== null}
+                            onSelect={() => void handleCopyAiWechatHtml('black-orange-imprint', '黑橙刊刻风')}
+                          >
+                            <span>
+                              {wechatAiGeneratingTheme === 'black-orange-imprint'
+                                ? '黑橙刊刻风生成中...'
+                                : '黑橙刊刻风（AI）'}
+                            </span>
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+
+                    {onToggleFullscreen && (
+                      <IconButton
+                        onClick={onToggleFullscreen}
+                        tooltip={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen'}
+                        label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+                      >
+                        {isFullscreen ? (
+                          <Minimize2 className="w-4 h-4" />
+                        ) : (
+                          <Maximize2 className="w-4 h-4" />
+                        )}
+                      </IconButton>
+                    )}
+                    <IconButton
+                      onClick={() => {
+                        if (activeFileTabId) {
+                          void closeProjectFileTab(activeFileTabId);
+                        } else {
+                          closePreview();
+                        }
+                      }}
+                      label="Close preview"
+                    >
+                      <X className="w-4 h-4" />
+                    </IconButton>
+                  </div>
+                </div>
+              )}
+
+              {!showProjectFileTabs && !isEditableMarkdownPreview ? (
                 <div className="drag-region flex items-center justify-between gap-2 pb-2">
                   <div className="min-w-0">
                     <div className="text-xs text-[var(--text-muted)]">Preview</div>
@@ -2684,29 +3163,6 @@ export function ProjectTreePanel({
                       windowControlsInset={isFullscreen}
                       saveState={saveState}
                       saveError={saveError}
-                      toolbarActions={
-                        <>
-                          {onToggleFullscreen && (
-                            <IconButton
-                              onClick={onToggleFullscreen}
-                              tooltip={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen'}
-                              label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-                            >
-                              {isFullscreen ? (
-                                <Minimize2 className="w-4 h-4" />
-                              ) : (
-                                <Maximize2 className="w-4 h-4" />
-                              )}
-                            </IconButton>
-                          )}
-                          <IconButton
-                            onClick={closePreview}
-                            label="Close preview"
-                          >
-                            <X className="w-4 h-4" />
-                          </IconButton>
-                        </>
-                      }
                       onChange={handleDraftTextChange}
                       onSave={handleSaveText}
                       onRegisterBridge={registerMarkdownBridge}
@@ -2749,6 +3205,7 @@ export function ProjectTreePanel({
                         />
                         <div className="aegis-mdx-source-fill">
                           <ProjectTextEditor
+                            ref={registerTextEditorBridge}
                             value={draftText}
                             onChange={handleDraftTextChange}
                             onSave={() => handleSaveText()}
@@ -2779,6 +3236,7 @@ export function ProjectTreePanel({
                           />
                           <div className="aegis-mdx-source-fill">
                             <ProjectTextEditor
+                              ref={registerTextEditorBridge}
                               value={draftText}
                               onChange={handleDraftTextChange}
                               onSave={() => handleSaveText()}
@@ -2802,11 +3260,11 @@ export function ProjectTreePanel({
                         </div>
                       </div>
                     ) : selectedPreview.editable ? (
-                      <textarea
+                      <ProjectTextEditor
+                        ref={registerTextEditorBridge}
                         value={draftText}
-                        onChange={(e) => handleDraftTextChange(e.target.value)}
-                        className="w-full h-full min-h-[220px] resize-none bg-transparent outline-none font-mono text-sm whitespace-pre-wrap"
-                        spellCheck={false}
+                        onChange={handleDraftTextChange}
+                        onSave={() => handleSaveText()}
                       />
                     ) : selectedPreview.name?.toLowerCase().endsWith('.txt') ? (
                       <TextFileReader

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -1680,7 +1680,8 @@ button.aegis-mdx-metadata-key:hover {
 
 .aegis-cm-frontmatter-widget {
   cursor: text;
-  margin: 0 auto;
+  margin-block: 0;
+  margin-inline: auto;
   user-select: none;
 }
 
@@ -2254,13 +2255,23 @@ button.aegis-mdx-metadata-key:hover {
   cursor: pointer;
 }
 
+.aegis-cm-block-widget {
+  box-sizing: border-box;
+  margin-block: 0;
+}
+
 .aegis-cm-code-widget {
+  display: block;
+  max-width: 100%;
+  padding: 0.95rem 0 0.72rem;
+  cursor: text;
+}
+
+.aegis-cm-code-frame {
   overflow: hidden;
-  margin: 0.95rem 0 0.72rem;
   border: 1px solid color-mix(in srgb, var(--border) 76%, var(--text-muted) 12%);
   border-radius: 6px;
   background: color-mix(in srgb, var(--preview-surface) 92%, var(--bg-tertiary));
-  cursor: text;
 }
 
 .aegis-cm-code-header {
@@ -2330,17 +2341,15 @@ button.aegis-mdx-metadata-key:hover {
 }
 
 .aegis-cm-code-source-line.is-first {
-  margin-top: 0.95rem;
   border-top: 1px solid color-mix(in srgb, var(--border) 76%, var(--text-muted) 12%);
   border-radius: 6px 6px 0 0;
-  padding-top: 0.54rem;
+  padding-top: 1.49rem;
 }
 
 .aegis-cm-code-source-line.is-last {
   border-bottom: 1px solid color-mix(in srgb, var(--border) 76%, var(--text-muted) 12%);
   border-radius: 0 0 6px 6px;
-  padding-bottom: 0.58rem;
-  margin-bottom: 0.72rem;
+  padding-bottom: 1.3rem;
 }
 
 .aegis-cm-code-source-line.is-marker {
@@ -2349,8 +2358,9 @@ button.aegis-mdx-metadata-key:hover {
 
 .aegis-cm-image-widget {
   display: block;
+  box-sizing: border-box;
   max-width: 100%;
-  margin: 1rem 0 0.45rem;
+  padding: 1rem 0 0.45rem;
   cursor: text;
 }
 
@@ -2377,7 +2387,9 @@ button.aegis-mdx-metadata-key:hover {
 }
 
 .aegis-cm-table-widget {
-  margin: 1rem 0;
+  display: block;
+  max-width: 100%;
+  padding: 1rem 0;
   cursor: text;
 }
 

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -110,6 +110,7 @@
   --radius-xl: 12px;
   --radius-2xl: 16px;
   --app-window-corner-radius: 16px;
+  --app-window-controls-inset-left: 104px;
 
   /* Popover / dropdown surface (unified) */
   --popover-bg: #FFFFFF;
@@ -2005,8 +2006,9 @@ button.aegis-mdx-metadata-key:hover {
   overflow: hidden;
 }
 
-.aegis-md-editor.window-controls-inset .aegis-md-toolbar {
-  padding-left: 104px;
+.aegis-md-editor.window-controls-inset .aegis-md-toolbar,
+.aegis-project-file-tabs.window-controls-inset {
+  padding-left: var(--app-window-controls-inset-left);
 }
 
 .aegis-md-toolbar-tools {


### PR DESCRIPTION
## Summary
- fix Markdown editor block click placement and add verification coverage
- add editable project file tabs for Markdown, MDX, and text files
- cache editable tab preview/draft text so switching tabs no longer shows center Loading
- keep active-file save/flush semantics before switching tabs and refresh cached tabs in the background

## Verification
- npm run verify:markdown-editor
- npm run build
- git diff --check