### PR TITLE
fix: stabilize markdown drag selection

### DIFF
--- a/scripts/verify-markdown-editor.mjs
+++ b/scripts/verify-markdown-editor.mjs
@@ -79,6 +79,12 @@ draft: false
 
 This line has [Baidu](www.baidu.com), [GitHub](https://github.com/DylanDDeng), and https://example.com/plain.
 
+## Reverse Selection Heading
+
+### Reverse Selection Subheading
+
+Reverse selection paragraph below heading.
+
 Inline probe: anchor
 
 Inline \\\`code\\\`, **bold**, *italic*, and ~~strike~~.
@@ -134,6 +140,24 @@ function Harness() {
   valueRef.current = value;
 
   useEffect(() => {
+    const measureLineViewportPosition = (needle) => {
+      const line = Array.from(document.querySelectorAll('.cm-line'))
+        .find((node) => (node.textContent || '').includes(needle));
+      const main = document.querySelector('.aegis-md-main');
+      if (!line || !main) return null;
+      const lineRect = line.getBoundingClientRect();
+      const mainRect = main.getBoundingClientRect();
+      return {
+        lineTop: lineRect.top,
+        mainTop: mainRect.top,
+        offset: lineRect.top - mainRect.top,
+        height: lineRect.height,
+        scrollTop: main.scrollTop,
+        className: line.className,
+        text: line.textContent || '',
+      };
+    };
+
     window.__AegisMarkdownVerify = {
       ready: true,
       getValue: () => valueRef.current,
@@ -218,24 +242,116 @@ function Harness() {
         button.click();
         return { before, text: button.textContent || '' };
       },
-      getLineViewportPosition: (needle) => {
-        const line = Array.from(document.querySelectorAll('.cm-line'))
-          .find((node) => (node.textContent || '').includes(needle));
-        const main = document.querySelector('.aegis-md-main');
-        if (!line || !main) return null;
-        const lineRect = line.getBoundingClientRect();
-        const mainRect = main.getBoundingClientRect();
-        return {
-          lineTop: lineRect.top,
-          mainTop: mainRect.top,
-          offset: lineRect.top - mainRect.top,
-          text: line.textContent || '',
-        };
-      },
+      getLineViewportPosition: measureLineViewportPosition,
       getSelectionLineText: () => {
         const view = findView();
         if (!view) return '';
         return view.state.doc.lineAt(view.state.selection.main.from).text;
+      },
+      getSelectionText: () => {
+        const view = findView();
+        if (!view) return '';
+        const selection = view.state.selection.main;
+        return view.state.sliceDoc(selection.from, selection.to);
+      },
+      simulateReverseSelection: (startNeedle, endNeedle, sampleNeedle) => {
+        const view = findView();
+        if (!view) return null;
+        const text = view.state.doc.toString();
+        const startIndex = text.indexOf(startNeedle);
+        const endIndex = text.indexOf(endNeedle);
+        if (startIndex < 0 || endIndex < 0) return null;
+
+        const start = startIndex + startNeedle.length;
+        const end = endIndex;
+        const steps = 8;
+        const samples = [measureLineViewportPosition(sampleNeedle)];
+        view.focus();
+        for (let index = 1; index <= steps; index += 1) {
+          const ratio = index / steps;
+          const pos = Math.round(start + ((end - start) * ratio));
+          view.dispatch({ selection: EditorSelection.range(start, pos) });
+          samples.push(measureLineViewportPosition(sampleNeedle));
+        }
+        const selection = view.state.selection.main;
+        return {
+          start,
+          end,
+          sampleNeedle,
+          samples,
+          selectionFrom: selection.from,
+          selectionTo: selection.to,
+          selectionText: view.state.sliceDoc(selection.from, selection.to),
+        };
+      },
+      simulateUpwardAutoscrollSelection: async (startNeedle) => {
+        const view = findView();
+        const main = document.querySelector('.aegis-md-main');
+        if (!view || !main) return null;
+        const startLine = Array.from(document.querySelectorAll('.cm-line'))
+          .find((node) => (node.textContent || '').includes(startNeedle));
+        if (!startLine) return null;
+
+        const lineRect = startLine.getBoundingClientRect();
+        const mainRect = main.getBoundingClientRect();
+        const startX = lineRect.left + Math.min(Math.max(lineRect.width * 0.45, 12), Math.max(12, lineRect.width - 12));
+        const startY = lineRect.top + (lineRect.height / 2);
+        const dragY = mainRect.top - 32;
+        const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+        const moveEvent = () => new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          clientX: startX,
+          clientY: dragY,
+          button: 0,
+          buttons: 1,
+        });
+
+        const beforeScrollTop = main.scrollTop;
+        startLine.dispatchEvent(new MouseEvent('mousedown', {
+          bubbles: true,
+          cancelable: true,
+          clientX: startX,
+          clientY: startY,
+          button: 0,
+          buttons: 1,
+        }));
+        document.dispatchEvent(moveEvent());
+
+        const samples = [];
+        for (let index = 0; index < 18; index += 1) {
+          await wait(60);
+          document.dispatchEvent(moveEvent());
+          samples.push({
+            index,
+            scrollTop: main.scrollTop,
+            selectionText: view.state.sliceDoc(
+              view.state.selection.main.from,
+              view.state.selection.main.to
+            ),
+          });
+        }
+
+        document.dispatchEvent(new MouseEvent('mouseup', {
+          bubbles: true,
+          cancelable: true,
+          clientX: startX,
+          clientY: dragY,
+          button: 0,
+          buttons: 0,
+        }));
+        await wait(120);
+
+        const selection = view.state.selection.main;
+        return {
+          beforeScrollTop,
+          afterScrollTop: main.scrollTop,
+          startNeedle,
+          selectionFrom: selection.from,
+          selectionTo: selection.to,
+          selectionText: view.state.sliceDoc(selection.from, selection.to),
+          samples,
+        };
       },
       measureBacktickPairCaret: () => {
         const view = findView();
@@ -523,6 +639,16 @@ app.whenReady().then(async () => {
     await clickPoint(win, paragraphClickPoint);
     const paragraphSelectionLine = await win.webContents.executeJavaScript('window.__AegisMarkdownVerify.getSelectionLineText()', true);
 
+    await win.webContents.executeJavaScript('window.__AegisMarkdownVerify.scrollLineIntoView("Reverse Selection Heading")', true);
+    await delay(180);
+    const reverseHeadingSelection = await win.webContents.executeJavaScript(
+      'window.__AegisMarkdownVerify.simulateReverseSelection("Reverse selection paragraph below heading.", "Reverse Selection Heading", "Reverse Selection Subheading")',
+      true
+    );
+    if (!reverseHeadingSelection) throw new Error('Unable to simulate reverse heading selection.');
+    const reverseHeadingBefore = reverseHeadingSelection.samples?.[0] || null;
+    const reverseSelectionText = reverseHeadingSelection.selectionText || '';
+
     const afterCodeClickPoint = await findVisibleLineClickPoint(win, 'Paragraph immediately after code preview.');
     if (!afterCodeClickPoint) throw new Error('Unable to find after-code paragraph line click point.');
     await clickPoint(win, afterCodeClickPoint);
@@ -572,6 +698,14 @@ app.whenReady().then(async () => {
     await clickPoint(win, deepParagraphClickPoint);
     const deepParagraphSelectionLine = await win.webContents.executeJavaScript('window.__AegisMarkdownVerify.getSelectionLineText()', true);
 
+    await win.webContents.executeJavaScript('window.__AegisMarkdownVerify.scrollLineIntoView("Tail paragraph 10")', true);
+    await delay(180);
+    const upwardAutoscrollSelection = await win.webContents.executeJavaScript(
+      'window.__AegisMarkdownVerify.simulateUpwardAutoscrollSelection("Tail paragraph 10")',
+      true
+    );
+    if (!upwardAutoscrollSelection) throw new Error('Unable to simulate upward autoscroll selection.');
+
     // Regression: an unterminated triple-backtick fence already present in a
     // document must NOT swallow the content below it into a code block.
     await win.webContents.executeJavaScript('window.__AegisMarkdownVerify.focusEnd()', true);
@@ -605,6 +739,9 @@ app.whenReady().then(async () => {
       headingSelectionLine,
       paragraphClickPoint,
       paragraphSelectionLine,
+      reverseHeadingBefore,
+      reverseHeadingSelection,
+      reverseSelectionText,
       afterCodeClickPoint,
       afterCodeSelectionLine,
       afterTableClickPoint,
@@ -614,6 +751,7 @@ app.whenReady().then(async () => {
       outlineTargetPosition,
       deepParagraphClickPoint,
       deepParagraphSelectionLine,
+      upwardAutoscrollSelection,
       midFenceSnapshot,
       finalFullValue,
       imageReads,
@@ -682,6 +820,9 @@ async function main() {
       headingSelectionLine,
       paragraphClickPoint,
       paragraphSelectionLine,
+      reverseHeadingBefore,
+      reverseHeadingSelection,
+      reverseSelectionText,
       afterCodeClickPoint,
       afterCodeSelectionLine,
       afterTableClickPoint,
@@ -691,6 +832,7 @@ async function main() {
       outlineTargetPosition,
       deepParagraphClickPoint,
       deepParagraphSelectionLine,
+      upwardAutoscrollSelection,
       midFenceSnapshot,
       finalFullValue,
       imageReads,
@@ -760,6 +902,37 @@ async function main() {
       paragraphSelectionLine.includes('This line has'),
       `Clicking the rendered paragraph selected the wrong source line: ${JSON.stringify({ paragraphClickPoint, paragraphSelectionLine })}`
     );
+    assert(reverseHeadingBefore, 'Unable to measure reverse selection heading before selection.');
+    assert(
+      reverseHeadingSelection?.samples?.filter(Boolean).length >= 4,
+      `Reverse heading selection did not collect enough geometry samples: ${JSON.stringify(reverseHeadingSelection)}`
+    );
+    {
+      const samples = reverseHeadingSelection.samples.filter(Boolean);
+      const heights = samples.map((sample) => sample.height).filter((value) => Number.isFinite(value));
+      const offsets = samples.map((sample) => sample.offset).filter((value) => Number.isFinite(value));
+      const scrollTops = samples.map((sample) => sample.scrollTop).filter((value) => Number.isFinite(value));
+      const heightDelta = Math.max(...heights) - Math.min(...heights);
+      const offsetDelta = Math.max(...offsets) - Math.min(...offsets);
+      const scrollDelta = Math.max(...scrollTops) - Math.min(...scrollTops);
+      assert(
+        heightDelta <= 2,
+        `Reverse selection through headings changed heading line height: ${JSON.stringify({ heightDelta, reverseHeadingBefore, reverseHeadingSelection })}`
+      );
+      assert(
+        offsetDelta <= 2,
+        `Reverse selection through headings moved the heading line: ${JSON.stringify({ offsetDelta, reverseHeadingBefore, reverseHeadingSelection })}`
+      );
+      assert(
+        scrollDelta <= 2,
+        `Reverse selection through headings changed the main scroll position: ${JSON.stringify({ scrollDelta, reverseHeadingBefore, reverseHeadingSelection })}`
+      );
+    }
+    assert(
+      reverseSelectionText.includes('Reverse Selection Subheading')
+        && reverseSelectionText.includes('Reverse selection paragraph below heading.'),
+      `Reverse selection did not cover the expected heading section: ${JSON.stringify({ reverseSelectionText, reverseHeadingSelection })}`
+    );
     assert(
       afterCodeSelectionLine.includes('Paragraph immediately after code preview.'),
       `Clicking a line after a rendered code widget selected the wrong source line: ${JSON.stringify({ afterCodeClickPoint, afterCodeSelectionLine })}`
@@ -779,6 +952,15 @@ async function main() {
     assert(
       deepParagraphSelectionLine.includes('Target paragraph after the outline jump.'),
       `Clicking a line after rendered image widgets selected the wrong source line: ${JSON.stringify({ deepParagraphClickPoint, deepParagraphSelectionLine })}`
+    );
+    assert(
+      upwardAutoscrollSelection.afterScrollTop < upwardAutoscrollSelection.beforeScrollTop - 120,
+      `Dragging selection above the editor did not autoscroll upward: ${JSON.stringify(upwardAutoscrollSelection)}`
+    );
+    assert(
+      upwardAutoscrollSelection.selectionText.includes('Tail paragraph 10')
+        && upwardAutoscrollSelection.selectionText.length > 80,
+      `Upward autoscroll selection did not keep extending the selected text: ${JSON.stringify(upwardAutoscrollSelection)}`
     );
     assert(
       initialSnapshot.outlineTriggerTexts.length > 0

--- a/src/ui/components/ProjectMarkdownEditor.tsx
+++ b/src/ui/components/ProjectMarkdownEditor.tsx
@@ -3,6 +3,7 @@ import { EditorSelection, EditorState, StateEffect, StateField, Transaction, typ
 import {
   Decoration,
   EditorView,
+  ViewPlugin,
   WidgetType,
   drawSelection,
   highlightActiveLine,
@@ -147,6 +148,9 @@ const METADATA_VISIBLE_ROWS = 8;
 const OUTLINE_TARGET_MIN_TOP_OFFSET_PX = 72;
 const OUTLINE_TARGET_MAX_TOP_OFFSET_PX = 140;
 const OUTLINE_TARGET_VIEWPORT_RATIO = 0.16;
+const MARKDOWN_SELECTION_AUTOSCROLL_MARGIN_PX = 56;
+const MARKDOWN_SELECTION_AUTOSCROLL_MAX_STEP_PX = 42;
+const MARKDOWN_SELECTION_AUTOSCROLL_MIN_STEP_PX = 8;
 const URL_CANDIDATE_RE = /(?:https?:\/\/|www\.)[^\s<>"'`]+/gi;
 const TRAILING_URL_PUNCTUATION_RE = /[.,;:!?，。！？；：、)\]}）】》]+$/u;
 const MARKDOWN_IMAGE_MIME_TYPES = new Set([
@@ -1304,10 +1308,16 @@ function addInlineMarkdownDecorations(
 ) {
   const markdownLinkRanges: Array<{ from: number; to: number }> = [];
   const heading = /^(#{1,6})\s+/.exec(lineText);
-  if (heading && !activeLine) {
+  if (heading) {
     const level = heading[1].length;
-    decorations.push(Decoration.line({ class: `aegis-cm-heading-line level-${level}` }).range(lineFrom));
-    addHiddenRange(decorations, lineFrom, lineFrom + heading[0].length);
+    decorations.push(
+      Decoration.line({
+        class: `aegis-cm-heading-line level-${level} ${activeLine ? 'is-source' : 'is-preview'}`,
+      }).range(lineFrom)
+    );
+    if (!activeLine) {
+      addHiddenRange(decorations, lineFrom, lineFrom + heading[0].length);
+    }
   }
 
   const task = /^(\s*[-*+]\s+)(\[[ xX]\])\s+/.exec(lineText);
@@ -1558,28 +1568,181 @@ function createLivePreviewDecorationsField(cwd: string, filePath: string): State
   });
 }
 
-function createPointerStablePreviewExtension(): Extension {
-  const startPointerSelection = (event: MouseEvent, view: EditorView) => {
+class PointerStablePreviewPlugin {
+  private selecting = false;
+  private selectionAnchor: number | null = null;
+  private pointerClientX = 0;
+  private pointerClientY = 0;
+  private autoscrollFrame: number | null = null;
+  private readonly abortController = new AbortController();
+
+  constructor(private readonly view: EditorView) {
+    const doc = view.dom.ownerDocument;
+    const win = doc.defaultView;
+    const listenerOptions = { signal: this.abortController.signal };
+    doc.addEventListener('mousemove', this.handleDocumentMouseMove, listenerOptions);
+    doc.addEventListener('mouseup', this.endPointerSelection, listenerOptions);
+    doc.addEventListener('pointerup', this.endPointerSelection, listenerOptions);
+    doc.addEventListener('pointercancel', this.endPointerSelection, listenerOptions);
+    doc.addEventListener('touchmove', this.handleDocumentTouchMove, listenerOptions);
+    doc.addEventListener('touchend', this.endPointerSelection, listenerOptions);
+    doc.addEventListener('touchcancel', this.endPointerSelection, listenerOptions);
+    win?.addEventListener('blur', this.endPointerSelection, listenerOptions);
+  }
+
+  startMouseSelection(event: MouseEvent) {
     if (event.button !== 0) return false;
-    view.dispatch({ effects: markdownPointerSelectingEffect.of(true) });
+    this.startPointerSelection(event.clientX, event.clientY);
     return false;
-  };
-  const endPointerSelection = (_event: Event, view: EditorView) => {
-    view.dispatch({ effects: markdownPointerSelectingEffect.of(false) });
+  }
+
+  startTouchSelection(event: TouchEvent) {
+    const touch = event.touches[0] || event.changedTouches[0];
+    if (touch) {
+      this.startPointerSelection(touch.clientX, touch.clientY);
+    }
     return false;
+  }
+
+  endLocalPointerSelection() {
+    this.endPointerSelection();
+    return false;
+  }
+
+  destroy() {
+    this.selecting = false;
+    this.selectionAnchor = null;
+    this.cancelAutoscroll();
+    this.abortController.abort();
+  }
+
+  private startPointerSelection(clientX: number, clientY: number) {
+    this.pointerClientX = clientX;
+    this.pointerClientY = clientY;
+    this.selectionAnchor = this.view.posAtCoords({ x: clientX, y: clientY }, false);
+    if (this.selecting) return;
+    this.selecting = true;
+    this.view.dispatch({ effects: markdownPointerSelectingEffect.of(true) });
+    this.requestAutoscrollFrame();
+  }
+
+  private endPointerSelection = () => {
+    if (!this.selecting) return;
+    this.selecting = false;
+    this.selectionAnchor = null;
+    this.cancelAutoscroll();
+    this.view.dispatch({ effects: markdownPointerSelectingEffect.of(false) });
   };
 
-  return EditorView.domEventHandlers({
-    mousedown: startPointerSelection,
-    mouseup: endPointerSelection,
-    mouseleave: endPointerSelection,
-    touchstart: (_event, view) => {
-      view.dispatch({ effects: markdownPointerSelectingEffect.of(true) });
-      return false;
+  private handleDocumentMouseMove = (event: MouseEvent) => {
+    if (!this.selecting) return;
+    if (event.buttons === 0) {
+      this.endPointerSelection();
+      return;
+    }
+    this.pointerClientX = event.clientX;
+    this.pointerClientY = event.clientY;
+    this.requestAutoscrollFrame();
+  };
+
+  private handleDocumentTouchMove = (event: TouchEvent) => {
+    if (!this.selecting) return;
+    const touch = event.touches[0] || event.changedTouches[0];
+    if (!touch) return;
+    this.pointerClientX = touch.clientX;
+    this.pointerClientY = touch.clientY;
+    this.requestAutoscrollFrame();
+  };
+
+  private requestAutoscrollFrame() {
+    if (this.autoscrollFrame !== null) return;
+    const win = this.view.dom.ownerDocument.defaultView;
+    if (!win) return;
+    this.autoscrollFrame = win.requestAnimationFrame(this.runAutoscroll);
+  }
+
+  private cancelAutoscroll() {
+    if (this.autoscrollFrame === null) return;
+    const win = this.view.dom.ownerDocument.defaultView;
+    if (win) {
+      win.cancelAnimationFrame(this.autoscrollFrame);
+    }
+    this.autoscrollFrame = null;
+  }
+
+  private runAutoscroll = () => {
+    this.autoscrollFrame = null;
+    if (!this.selecting) return;
+
+    const scroller = this.view.dom.closest<HTMLElement>('.aegis-md-main');
+    if (!scroller) return;
+
+    const rect = scroller.getBoundingClientRect();
+    const delta = this.getVerticalAutoscrollDelta(rect);
+    if (delta === 0) return;
+
+    const previousScrollTop = scroller.scrollTop;
+    const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    scroller.scrollTop = Math.min(maxScrollTop, Math.max(0, previousScrollTop + delta));
+
+    if (scroller.scrollTop !== previousScrollTop) {
+      this.extendSelectionToPointer();
+      this.requestAutoscrollFrame();
+    }
+  };
+
+  private getVerticalAutoscrollDelta(rect: DOMRect) {
+    const { pointerClientY } = this;
+    if (pointerClientY < rect.top + MARKDOWN_SELECTION_AUTOSCROLL_MARGIN_PX) {
+      const distance = rect.top + MARKDOWN_SELECTION_AUTOSCROLL_MARGIN_PX - pointerClientY;
+      return -this.getAutoscrollStep(distance);
+    }
+    if (pointerClientY > rect.bottom - MARKDOWN_SELECTION_AUTOSCROLL_MARGIN_PX) {
+      const distance = pointerClientY - (rect.bottom - MARKDOWN_SELECTION_AUTOSCROLL_MARGIN_PX);
+      return this.getAutoscrollStep(distance);
+    }
+    return 0;
+  }
+
+  private getAutoscrollStep(distance: number) {
+    return Math.min(
+      MARKDOWN_SELECTION_AUTOSCROLL_MAX_STEP_PX,
+      Math.max(MARKDOWN_SELECTION_AUTOSCROLL_MIN_STEP_PX, Math.ceil(distance * 0.62))
+    );
+  }
+
+  private extendSelectionToPointer() {
+    if (this.selectionAnchor === null) return;
+    const head = this.view.posAtCoords(
+      { x: this.pointerClientX, y: this.pointerClientY },
+      false
+    );
+    this.view.dispatch({
+      selection: EditorSelection.range(this.selectionAnchor, head),
+      annotations: Transaction.userEvent.of('select.pointer'),
+    });
+  }
+}
+
+function createPointerStablePreviewExtension(): Extension {
+  return ViewPlugin.fromClass(PointerStablePreviewPlugin, {
+    eventHandlers: {
+      mousedown(event) {
+        return this.startMouseSelection(event);
+      },
+      mouseup() {
+        return this.endLocalPointerSelection();
+      },
+      touchstart(event) {
+        return this.startTouchSelection(event);
+      },
+      touchend() {
+        return this.endLocalPointerSelection();
+      },
+      touchcancel() {
+        return this.endLocalPointerSelection();
+      },
     },
-    touchend: endPointerSelection,
-    touchcancel: endPointerSelection,
-    blur: endPointerSelection,
   });
 }
 

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -2187,6 +2187,10 @@ button.aegis-mdx-metadata-key:hover {
   font-weight: 720;
 }
 
+.aegis-cm-heading-line.is-source {
+  color: color-mix(in srgb, var(--text-primary) 88%, var(--text-secondary));
+}
+
 .aegis-cm-heading-line.level-1 {
   padding: 0 0 0.85rem;
   font-size: 34px;


### PR DESCRIPTION
## Summary
- keep Markdown heading rows on a stable layout while source markers are visible during selection
- add outer viewport autoscroll so drag selection can continue past the visible editor area
- extend the Markdown editor verifier for reverse heading selection geometry and upward autoscroll

## Validation
- npm run verify:markdown-editor
- npm run build