### PR TITLE
Preserve right panel tabs and state across collapse

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -168,6 +168,7 @@ export function App() {
     terminalDrawerHeight,
     rightUtilityTabs,
     activeRightUtilityTab,
+    rightUtilityPanelHidden,
     rightPanelFullscreen,
     sessionsLoaded,
     setProjectTreeCollapsed,
@@ -179,6 +180,7 @@ export function App() {
     openRightUtilityTab,
     closeRightUtilityTab: closeRightUtilityTabInStore,
     closeRightUtilityPanels: closeRightUtilityPanelsInStore,
+    showRightUtilityPanels,
     setRightPanelFullscreen,
     closeSplitChat,
     openSplitChat,
@@ -450,9 +452,10 @@ export function App() {
 
   const activeUtilityPanel = useMemo(() => {
     if (rightPanelLauncherOpen) return 'launcher' as const;
+    if (rightUtilityPanelHidden) return null;
     if (activeRightUtilityTab) return getProjectUtilityTabKind(activeRightUtilityTab);
     return null;
-  }, [activeRightUtilityTab, rightPanelLauncherOpen]);
+  }, [activeRightUtilityTab, rightPanelLauncherOpen, rightUtilityPanelHidden]);
 
   const closeRightUtilityPanels = useCallback(() => {
     setRightPanelLauncherOpen(false);
@@ -520,13 +523,28 @@ export function App() {
       closeRightUtilityPanels();
       return;
     }
+    if (rightUtilityTabs.length > 0) {
+      // Re-open with the previous tabs and active tab intact.
+      showRightUtilityPanels();
+      const target = activeRightUtilityTab ?? rightUtilityTabs[0];
+      if (target) activateRightUtilityContent(target);
+      return;
+    }
     openRightUtilityLauncher();
-  }, [activeUtilityPanel, closeRightUtilityPanels, openRightUtilityLauncher]);
+  }, [
+    activateRightUtilityContent,
+    activeRightUtilityTab,
+    activeUtilityPanel,
+    closeRightUtilityPanels,
+    openRightUtilityLauncher,
+    rightUtilityTabs,
+    showRightUtilityPanels,
+  ]);
 
   useEffect(() => {
-    if (!activeRightUtilityTab) return;
+    if (!activeRightUtilityTab || rightUtilityPanelHidden) return;
     activateRightUtilityContent(activeRightUtilityTab);
-  }, [activeRightUtilityTab, activateRightUtilityContent]);
+  }, [activeRightUtilityTab, activateRightUtilityContent, rightUtilityPanelHidden]);
 
   useEffect(() => {
     const nextStatuses = new Map<string, SessionStatus>();
@@ -818,7 +836,10 @@ export function App() {
             <WorkspaceHost
               codexModelConfig={codexModelConfig}
               onWorkspaceGitChanged={refreshEnvironmentGit}
-              dockSecondaryPane={rightUtilityTabs.includes('side-chat') || activeUtilityPanel === 'side-chat'}
+              dockSecondaryPane={
+                activeUtilityPanel === 'side-chat' ||
+                (!rightUtilityPanelHidden && rightUtilityTabs.includes('side-chat'))
+              }
             />
 
             <TerminalDrawer
@@ -842,9 +863,12 @@ export function App() {
       </div>
 
       <AnimatePresence initial={false}>
-      {!showSettings && activeWorkspace === 'chat' && activeUtilityPanel !== null ? (
+      {!showSettings &&
+      activeWorkspace === 'chat' &&
+      (activeUtilityPanel !== null || (rightUtilityPanelHidden && rightUtilityTabs.length > 0)) ? (
         <RightUtilityWorkspace
           key="right-utility-workspace"
+          hidden={activeUtilityPanel === null}
           activePanel={activeUtilityPanel}
           tabs={rightUtilityTabDescriptors}
           activeTab={
@@ -969,6 +993,7 @@ function getUtilityTabIcon(target: ProjectUtilityPanelKind) {
 }
 
 function RightUtilityWorkspace({
+  hidden,
   activePanel,
   tabs,
   activeTab,
@@ -982,6 +1007,7 @@ function RightUtilityWorkspace({
   onTogglePanel,
   children,
 }: {
+  hidden: boolean;
   activePanel: PanelLauncherKind | null;
   tabs: ProjectUtilityTabDescriptor[];
   activeTab: ProjectUtilityPanelTarget | null;
@@ -1045,11 +1071,16 @@ function RightUtilityWorkspace({
     <motion.div
       data-right-utility-workspace
       data-active-panel={activePanel ?? 'none'}
+      aria-hidden={hidden}
       className={`relative flex h-full min-w-0 flex-col overflow-hidden border-l border-[var(--border)] bg-[var(--bg-primary)] ${
         fullscreen ? 'flex-1' : 'flex-shrink-0'
       }`}
+      style={{
+        pointerEvents: hidden ? 'none' : undefined,
+        borderLeftWidth: hidden ? 0 : undefined,
+      }}
       initial={{ width: 0 }}
-      animate={{ width: fullscreen ? 'auto' : width }}
+      animate={{ width: hidden ? 0 : fullscreen ? 'auto' : width }}
       exit={{ width: 0, transition: { type: 'tween', duration: 0.2, ease: [0.32, 0.72, 0, 1] } }}
       transition={
         skipWidthAnimation
@@ -1057,7 +1088,7 @@ function RightUtilityWorkspace({
           : { type: 'tween', duration: 0.24, ease: [0.32, 0.72, 0, 1] }
       }
     >
-      {!fullscreen ? (
+      {!fullscreen && !hidden ? (
         <div
           className="group absolute bottom-0 left-0 top-0 z-20 w-3 -translate-x-1/2 cursor-col-resize no-drag"
           onMouseDown={handleResizeStart}

--- a/src/ui/store/useAppStore.ts
+++ b/src/ui/store/useAppStore.ts
@@ -1095,6 +1095,7 @@ export const useAppStore = create<Store>()(
       projectPanelView: normalizeProjectPanelView(initialUiResumeState?.projectPanelView),
       rightUtilityTabs: initialRightUtilityTab ? [initialRightUtilityTab] : [],
       activeRightUtilityTab: initialRightUtilityTab,
+      rightUtilityPanelHidden: false,
       reviewDiffSelection: null,
       terminalDrawerOpen: resolveInitialTerminalDrawerOpen(initialUiResumeState),
       terminalDrawerHeight: sanitizeTerminalDrawerHeight(initialUiResumeState?.terminalDrawerHeight),
@@ -2105,6 +2106,7 @@ export const useAppStore = create<Store>()(
         projectTreeCollapsed: false,
         rightUtilityTabs: opened.tabs,
         activeRightUtilityTab: opened.activeTab,
+        rightUtilityPanelHidden: false,
         rightPanelFullscreen: state.rightPanelFullscreen,
       };
     });
@@ -2125,6 +2127,7 @@ export const useAppStore = create<Store>()(
         projectPanelView,
         rightUtilityTabs: opened ? opened.tabs : state.rightUtilityTabs,
         activeRightUtilityTab: opened ? opened.activeTab : state.activeRightUtilityTab,
+        rightUtilityPanelHidden: opened ? false : state.rightUtilityPanelHidden,
       };
     });
     persistUiResumeStateSnapshot(get());
@@ -2134,6 +2137,7 @@ export const useAppStore = create<Store>()(
     set((state) => ({
       activeRightUtilityTab: target,
       rightUtilityTabs: target ? addRightUtilityTab(state.rightUtilityTabs, target) : state.rightUtilityTabs,
+      rightUtilityPanelHidden: target ? false : state.rightUtilityPanelHidden,
     }));
   },
 
@@ -2144,6 +2148,7 @@ export const useAppStore = create<Store>()(
       const patch: Partial<Store> = {
         rightUtilityTabs: opened.tabs,
         activeRightUtilityTab: opened.activeTab,
+        rightUtilityPanelHidden: false,
       };
 
       if (activeKind === 'files' || activeKind === 'review') {
@@ -2184,6 +2189,7 @@ export const useAppStore = create<Store>()(
         reviewDiffSelection: normalizeReviewDiffSelection(selection),
         rightUtilityTabs: opened.tabs,
         activeRightUtilityTab: opened.activeTab,
+        rightUtilityPanelHidden: false,
         projectPanelView: 'changes',
         projectTreeCollapsed: false,
         browserPanelOpen: false,
@@ -2214,6 +2220,7 @@ export const useAppStore = create<Store>()(
         patch.projectTreeCollapsed = true;
         patch.browserPanelOpen = false;
         patch.rightPanelFullscreen = null;
+        patch.rightUtilityPanelHidden = false;
       }
       const targetKind = getRightUtilityTabKind(target);
       if (targetKind === 'browser' && state.rightPanelFullscreen === 'browser') {
@@ -2231,12 +2238,32 @@ export const useAppStore = create<Store>()(
   },
 
   closeRightUtilityPanels: () => {
+    // Keep the tab list and active tab so re-opening the panel restores the
+    // previous layout; only the visibility flag flips.
     set({
-      rightUtilityTabs: [],
-      activeRightUtilityTab: null,
+      rightUtilityPanelHidden: true,
       projectTreeCollapsed: true,
       browserPanelOpen: false,
       rightPanelFullscreen: null,
+    });
+    persistUiResumeStateSnapshot(get());
+  },
+
+  showRightUtilityPanels: () => {
+    set((state) => {
+      if (state.rightUtilityTabs.length === 0) {
+        return { rightUtilityPanelHidden: false };
+      }
+      const activeTab = state.activeRightUtilityTab ?? state.rightUtilityTabs[0];
+      const activeKind = getRightUtilityTabKind(activeTab);
+      return {
+        rightUtilityPanelHidden: false,
+        activeRightUtilityTab: activeTab,
+        projectTreeCollapsed: !(activeKind === 'files' || activeKind === 'review'),
+        projectPanelView:
+          activeKind === 'review' ? 'changes' : activeKind === 'files' ? 'files' : state.projectPanelView,
+        browserPanelOpen: activeKind === 'browser',
+      };
     });
     persistUiResumeStateSnapshot(get());
   },
@@ -2258,6 +2285,7 @@ export const useAppStore = create<Store>()(
         ? addRightUtilityTab(state.rightUtilityTabs, 'browser')
         : state.rightUtilityTabs,
       activeRightUtilityTab: browserPanelOpen ? 'browser' : state.activeRightUtilityTab,
+      rightUtilityPanelHidden: browserPanelOpen ? false : state.rightUtilityPanelHidden,
       rightPanelFullscreen:
         !browserPanelOpen && state.rightPanelFullscreen === 'browser'
           ? null
@@ -2273,6 +2301,7 @@ export const useAppStore = create<Store>()(
         projectTreeCollapsed: true,
         rightUtilityTabs: addRightUtilityTab(state.rightUtilityTabs, 'browser'),
         activeRightUtilityTab: 'browser',
+        rightUtilityPanelHidden: false,
       }));
       return;
     }
@@ -2285,6 +2314,7 @@ export const useAppStore = create<Store>()(
           browserPanelOpen: false,
           rightUtilityTabs: opened.tabs,
           activeRightUtilityTab: opened.activeTab,
+          rightUtilityPanelHidden: false,
         };
       });
       return;

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -308,6 +308,7 @@ export interface AppState {
   projectPanelView: ProjectPanelView;
   rightUtilityTabs: ProjectUtilityPanelTarget[];
   activeRightUtilityTab: ProjectUtilityPanelTarget | null;
+  rightUtilityPanelHidden: boolean;
   reviewDiffSelection: ReviewDiffSelection | null;
   terminalDrawerOpen: boolean;
   terminalDrawerHeight: number;
@@ -409,6 +410,7 @@ export interface AppActions {
   openReviewDiff: (selection: ReviewDiffSelectionInput) => void;
   closeRightUtilityTab: (target: ProjectUtilityPanelTarget) => void;
   closeRightUtilityPanels: () => void;
+  showRightUtilityPanels: () => void;
   setTerminalDrawerOpen: (open: boolean) => void;
   setTerminalDrawerHeight: (height: number) => void;
   setBrowserPanelOpen: (open: boolean) => void;


### PR DESCRIPTION
## Summary
- Collapsing the right utility panel no longer wipes the tab list: `closeRightUtilityPanels` now only sets a new `rightUtilityPanelHidden` flag instead of clearing `rightUtilityTabs`
- The workspace stays mounted while hidden, with its width animated to zero (reusing the existing expand/collapse animation), so component state survives — open file tabs, markdown editor content, diff expansion, terminal, and side chat
- Re-expanding via the panel toggle restores the previous tabs and active tab; the launcher only shows when no tabs exist
- Every action that opens panel content (turn diff cards, environment buttons, browser, fullscreen, etc.) clears the hidden flag so external entry points still reveal the panel
- Closing every tab individually still fully resets the panel, matching the old behavior
- While hidden the workspace is non-interactive (`pointer-events: none`, `aria-hidden`, border suppressed) and the side-chat dock check ignores hidden tabs

## Test plan
- `npm test` passes (terminal runtime validation, builtin agent checks, icon imports, review diff panel verification)
- `npm run build` succeeds
- TypeScript error set is byte-identical to master baseline (no new errors)
- Manual: expand panel → open a file / switch to Changes → collapse → re-expand restores the exact previous state

🤖 Generated with [Claude Code](https://claude.com/claude-code)