### PR TITLE
Fix fullscreen tab strip overlapping macOS traffic lights

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -879,6 +879,7 @@ export function App() {
           width={rightUtilityPanelWidth}
           onWidthChange={setRightUtilityPanelWidth}
           fullscreen={rightPanelFullscreen !== null}
+          windowControlsInset={rightPanelFullscreen !== null && sidebarCollapsed}
           onSelectTab={selectRightUtilityTab}
           onCloseTab={closeRightUtilityTab}
           onOpenTab={openRightUtilityTab}
@@ -1000,6 +1001,7 @@ function RightUtilityWorkspace({
   browserAvailable,
   width,
   fullscreen,
+  windowControlsInset,
   onWidthChange,
   onSelectTab,
   onCloseTab,
@@ -1014,6 +1016,7 @@ function RightUtilityWorkspace({
   browserAvailable: boolean;
   width: number;
   fullscreen: boolean;
+  windowControlsInset: boolean;
   onWidthChange: (width: number) => void;
   onSelectTab: (target: ProjectUtilityPanelTarget) => void;
   onCloseTab: (target: ProjectUtilityPanelTarget) => void;
@@ -1106,6 +1109,7 @@ function RightUtilityWorkspace({
           activeTab={activeTab}
           activePanel={activePanel}
           browserAvailable={browserAvailable}
+          windowControlsInset={windowControlsInset}
           onSelectTab={onSelectTab}
           onCloseTab={onCloseTab}
           onOpenTab={onOpenTab}
@@ -1195,6 +1199,7 @@ function RightUtilityTabStrip({
   activeTab,
   activePanel,
   browserAvailable,
+  windowControlsInset,
   onSelectTab,
   onCloseTab,
   onOpenTab,
@@ -1204,6 +1209,7 @@ function RightUtilityTabStrip({
   activeTab: ProjectUtilityPanelTarget | null;
   activePanel: PanelLauncherKind | null;
   browserAvailable: boolean;
+  windowControlsInset: boolean;
   onSelectTab: (target: ProjectUtilityPanelTarget) => void;
   onCloseTab: (target: ProjectUtilityPanelTarget) => void;
   onOpenTab: (target: ProjectUtilityPanelKind, options?: { newTab?: boolean }) => void;
@@ -1218,7 +1224,12 @@ function RightUtilityTabStrip({
   ];
 
   return (
-    <div className="drag-region flex h-10 shrink-0 items-center gap-1 border-b border-[var(--border)] bg-[var(--bg-primary)] px-2">
+    <div
+      className="drag-region flex h-10 shrink-0 items-center gap-1 border-b border-[var(--border)] bg-[var(--bg-primary)] px-2"
+      // In fullscreen with the sidebar collapsed the strip becomes the topmost
+      // bar at the window's left edge, so it must clear the traffic lights.
+      style={windowControlsInset ? { paddingLeft: 'var(--app-window-controls-inset-left)' } : undefined}
+    >
       <div className="no-drag flex min-w-0 flex-1 translate-y-1 items-end gap-1 overflow-x-auto">
 	        {tabs.map((tab) => {
 	          const Icon = getUtilityTabIcon(tab.kind);

--- a/src/ui/components/ProjectTreePanel.tsx
+++ b/src/ui/components/ProjectTreePanel.tsx
@@ -2994,7 +2994,7 @@ export function ProjectTreePanel({
             <div className={`h-full min-w-0 flex flex-col ${showProjectFileTabs || isEditableMarkdownPreview ? '' : 'px-3 py-3'}`}>
               {showProjectFileTabs && (
                 <div
-                  className={`aegis-project-file-tabs${isFullscreen ? ' window-controls-inset' : ''} drag-region flex h-11 flex-shrink-0 items-center gap-2 border-b border-[var(--border)] bg-[var(--bg-primary)] pl-2 pr-2`}
+                  className={`aegis-project-file-tabs${isFullscreen && !embedded ? ' window-controls-inset' : ''} drag-region flex h-11 flex-shrink-0 items-center gap-2 border-b border-[var(--border)] bg-[var(--bg-primary)] pl-2 pr-2`}
                 >
 	                  <div className="no-drag flex min-w-0 flex-1 items-end overflow-x-auto">
 	                    {openFileTabs.map((tab) => {
@@ -3258,7 +3258,7 @@ export function ProjectTreePanel({
                       filePath={selectedFilePath}
                       fileName={selectedPreview.name}
                       hideTitleBar
-                      windowControlsInset={isFullscreen}
+                      windowControlsInset={isFullscreen && !embedded}
                       saveState={saveState}
                       saveError={saveError}
                       onChange={handleDraftTextChange}


### PR DESCRIPTION
## Summary
- When a right panel is fullscreened, the workspace tab strip (`RightUtilityTabStrip`) is the topmost bar at the window's left edge and was overlapping the macOS traffic lights; it now gets the `--app-window-controls-inset-left` padding when fullscreen **and** the sidebar is collapsed (with the sidebar expanded the controls overlap the sidebar instead, so no inset is needed)
- The embedded file-tab row in `ProjectTreePanel` and the markdown editor toolbar dropped their fullscreen inset — they sit below the workspace strip now, so the old inset only produced a stray 104px indent

## Test plan
- `npm test` passes (terminal runtime validation, builtin agent checks, icon imports, review diff panel verification)
- `npm run build` succeeds; markdown editor verification script passes
- TypeScript error count identical to master baseline (no new errors)
- Manual: fullscreen the Files panel with sidebar collapsed — the tab strip clears the traffic lights and the file-tab row below no longer has the extra indent

🤖 Generated with [Claude Code](https://claude.com/claude-code)