### PR TITLE
Add CI: run tests and build on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test & Build (macOS)
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Configure Python for node-gyp
+        shell: bash
+        run: |
+          echo "PYTHON=${{ steps.setup-python.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "npm_config_python=${{ steps.setup-python.outputs.python-path }}" >> "$GITHUB_ENV"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build (Vite + TS)
+        run: npm run build


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml`: runs `npm test` (terminal runtime validation, builtin agent checks, icon import check, review diff panel verification) and `npm run build` on every pull request and push to master
- Mirrors the proven macOS toolchain setup from `release.yml` (Python for node-gyp, Node 22, npm cache) on a `macos-14` runner
- Concurrency group cancels superseded runs on the same ref

## Test plan
- This PR itself triggers the new workflow — merge only after the check goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)