### PR TITLE
[codex] prevent browser launcher menu clipping

### DIFF
--- a/src/electron/browserManager.ts
+++ b/src/electron/browserManager.ts
@@ -1,12 +1,12 @@
 // Per-session in-app browser manager.
 //
 // Based on dpcode (Emanuele-web04/dpcode) DesktopBrowserManager design but
-// scoped to `sessionId` (each chat session has its own tabs + WebContentsView
+// scoped to `sessionId` (each browser page has its own WebContentsView
 // lifecycle). Adds screenshot + page readout (text / links / selection) for
 // Agent integration.
 //
 // Key ideas:
-// 1. One WebContentsView per (sessionId, tabId) while the session is active.
+// 1. One visible WebContentsView per browser page while the session is active.
 // 2. At most one WebContentsView is attached to the BrowserWindow at a time.
 // 3. Inactive sessions are suspended after BROWSER_SESSION_SUSPEND_DELAY_MS
 //    to release Chromium renderer processes.
@@ -89,7 +89,7 @@ function cloneSessionState(state: SessionBrowserState): SessionBrowserState {
 
 function defaultTitleForUrl(url: string): string {
   if (url === ABOUT_BLANK_URL) {
-    return 'New tab';
+    return 'New page';
   }
   try {
     const parsed = new URL(url);
@@ -366,21 +366,31 @@ export class BrowserManager {
 
   newTab(input: BrowserNewTabInput): SessionBrowserState {
     const state = this.ensureWorkspace(input.sessionId);
-    const tab = createBrowserTab(normalizeUrlInput(input.url));
-    state.tabs = [...state.tabs, tab];
-    if (input.activate !== false || !state.activeTabId) {
-      state.activeTabId = tab.id;
+    const tab = this.resolveTab(state);
+    const retiredTabs = state.tabs.filter((item) => item.id !== tab.id);
+    for (const retiredTab of retiredTabs) {
+      this.destroyRuntime(input.sessionId, retiredTab.id);
     }
+    state.tabs = [tab];
+    state.activeTabId = tab.id;
+    tab.url = normalizeUrlInput(input.url);
+    tab.title = defaultTitleForUrl(tab.url);
+    tab.lastCommittedUrl = null;
+    tab.lastError = null;
 
     if (this.activeSessionId === input.sessionId) {
       this.resumeSession(input.sessionId);
-      if (state.activeTabId === tab.id && this.activeBounds) {
+      if (this.activeBounds) {
         this.ensureLiveRuntime(input.sessionId, tab.id);
         void this.loadTab(input.sessionId, tab.id, { force: true });
         this.attachActiveTab(input.sessionId, this.activeBounds);
       }
     } else {
+      this.destroyRuntime(input.sessionId, tab.id);
       tab.status = 'suspended';
+      tab.isLoading = false;
+      tab.canGoBack = false;
+      tab.canGoForward = false;
     }
 
     syncSessionLastError(state);
@@ -710,10 +720,7 @@ export class BrowserManager {
         return { action: 'deny' };
       }
       if (url.startsWith('http://') || url.startsWith('https://') || url === ABOUT_BLANK_URL) {
-        this.newTab({ sessionId, url, activate: true });
-        if (this.activeSessionId === sessionId && this.activeBounds) {
-          this.attachActiveTab(sessionId, this.activeBounds);
-        }
+        this.navigate({ sessionId, tabId, url });
         return { action: 'deny' };
       }
       void shell.openExternal(url);
@@ -1021,10 +1028,10 @@ export class BrowserManager {
       template.push({
         label: 'Search the web',
         click: () => {
-          this.newTab({
+          this.navigate({
             sessionId,
+            tabId,
             url: `${SEARCH_URL_PREFIX}${encodeURIComponent(selectionText)}`,
-            activate: true,
           });
         },
       });
@@ -1033,9 +1040,9 @@ export class BrowserManager {
     if (linkUrl) {
       if (hasSelection) template.push({ type: 'separator' });
       template.push({
-        label: 'Open link in new tab',
+        label: 'Open link',
         click: () => {
-          this.newTab({ sessionId, url: linkUrl, activate: true });
+          this.navigate({ sessionId, tabId, url: linkUrl });
         },
       });
       template.push({

--- a/src/electron/ipc-handlers.ts
+++ b/src/electron/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, clipboard, dialog, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, shell } from 'electron';
 import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'http';
 import { createReadStream, existsSync, mkdirSync, readFileSync, statSync, watch, type FSWatcher, promises as fsPromises } from 'fs';
 import { execFile } from 'child_process';
@@ -5864,6 +5864,50 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
     } catch (error) {
       return { ok: false, message: String(error) };
     }
+  });
+
+  ipcMainHandle('show-right-utility-tab-menu', async (
+    _event,
+    input: {
+      x?: number;
+      y?: number;
+      items?: Array<{
+        id: string;
+        label: string;
+        enabled?: boolean;
+        accelerator?: string | null;
+      }>;
+    }
+  ) => {
+    const items = Array.isArray(input?.items) ? input.items : [];
+    if (items.length === 0) {
+      return { ok: false, message: 'No menu items.' };
+    }
+
+    return await new Promise<{ ok: boolean; id?: string; message?: string }>((resolve) => {
+      let resolved = false;
+      const finish = (result: { ok: boolean; id?: string; message?: string }) => {
+        if (resolved) return;
+        resolved = true;
+        resolve(result);
+      };
+
+      const menu = Menu.buildFromTemplate(
+        items.map((item) => ({
+          label: item.label,
+          enabled: item.enabled !== false,
+          accelerator: item.accelerator ?? undefined,
+          click: () => finish({ ok: true, id: item.id }),
+        }))
+      );
+
+      menu.popup({
+        window: mainWindow,
+        x: Number.isFinite(input?.x) ? Math.round(input.x as number) : undefined,
+        y: Number.isFinite(input?.y) ? Math.round(input.y as number) : undefined,
+        callback: () => finish({ ok: true }),
+      });
+    });
   });
 
   // === IPC 模块注册（从 ipc-handlers.ts 拆分） ===

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -752,6 +752,19 @@ contextBridge.exposeInMainWorld('electron', {
     return ipcRenderer.invoke('open-external-url', url);
   },
 
+  showRightUtilityTabMenu: (input: {
+    x?: number;
+    y?: number;
+    items?: Array<{
+      id: string;
+      label: string;
+      enabled?: boolean;
+      accelerator?: string | null;
+    }>;
+  }) => {
+    return ipcRenderer.invoke('show-right-utility-tab-menu', input);
+  },
+
   // 订阅系统统计（预留）
   subscribeStatistics: (callback: (data: unknown) => void) => {
     const handler = (_: unknown, data: unknown) => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -262,6 +262,16 @@ declare global {
     saveSessionEnvironmentNote: (sessionId: string, note: string) => Promise<{ ok: boolean; note?: import('./shared/types').SessionEnvironmentNote; message?: string }>;
     refreshSessionEnvironmentRecap: (sessionId: string) => Promise<{ ok: boolean; recap?: import('./shared/types').SessionEnvironmentRecap; message?: string }>;
     openExternalUrl: (url: string) => Promise<{ ok: boolean; message?: string }>;
+    showRightUtilityTabMenu: (input: {
+      x?: number;
+      y?: number;
+      items?: Array<{
+        id: string;
+        label: string;
+        enabled?: boolean;
+        accelerator?: string | null;
+      }>;
+    }) => Promise<{ ok: boolean; id?: string; message?: string }>;
     subscribeStatistics: (callback: (data: StatisticsData) => void) => () => void;
     getStaticData: () => Promise<StaticData>;
     browser: {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -47,6 +47,7 @@ import { TerminalDrawer } from './components/TerminalDrawer';
 import { RightTerminalPanel } from './components/RightTerminalPanel';
 import { WorkspaceHost } from './components/WorkspaceHost';
 import { ChatPane } from './components/ChatPane';
+import { useBrowserStateStore } from './store/useBrowserStateStore';
 import { EnvironmentHub } from './components/environment/EnvironmentHub';
 import { useActiveEnvironmentContext } from './components/environment/useActiveEnvironmentContext';
 import { useGitEnvironment } from './components/environment/useGitEnvironment';
@@ -96,8 +97,36 @@ function isProjectUtilityFileTab(target: ProjectUtilityPanelTarget | null | unde
   return target === 'files' || Boolean(target?.startsWith('files:'));
 }
 
+function isProjectUtilityBrowserTab(target: ProjectUtilityPanelTarget | null | undefined): boolean {
+  return target === 'browser' || Boolean(target?.startsWith('browser:'));
+}
+
 function getProjectUtilityTabKind(target: ProjectUtilityPanelTarget): ProjectUtilityPanelKind {
-  return isProjectUtilityFileTab(target) ? 'files' : target;
+  if (isProjectUtilityFileTab(target)) return 'files';
+  if (isProjectUtilityBrowserTab(target)) return 'browser';
+  return target;
+}
+
+function getBrowserUtilitySessionId(chatSessionId: string, target: ProjectUtilityPanelTarget): string {
+  return target === 'browser' ? chatSessionId : `${chatSessionId}:${target}`;
+}
+
+function getBrowserUtilityLabel(
+  state: ReturnType<typeof useBrowserStateStore.getState>['sessionStatesBySessionId'][string] | null | undefined
+): string {
+  const activeTab =
+    state?.tabs.find((tab) => tab.id === state.activeTabId) ??
+    state?.tabs[0] ??
+    null;
+  const title = activeTab?.title?.trim();
+  if (title && title !== 'New tab' && title !== 'New page') return title;
+  const url = activeTab?.url?.trim();
+  if (!url || url === 'about:blank') return 'Browser';
+  try {
+    return new URL(url).hostname || 'Browser';
+  } catch {
+    return url;
+  }
 }
 
 function getDefaultRightUtilityPanelWidth(): number {
@@ -144,6 +173,7 @@ export function App() {
   const [activeProjectFileTabs, setActiveProjectFileTabs] = useState<
     Record<string, { filePath: string; name: string } | null>
   >({});
+  const browserSessionStates = useBrowserStateStore((s) => s.sessionStatesBySessionId);
 
   const {
     connected,
@@ -486,14 +516,30 @@ export function App() {
         return { id: tab, kind, label: 'Changes' };
       }
       if (kind === 'browser') {
-        return { id: tab, kind, label: 'Browser' };
+        const browserSessionId = activeSessionId
+          ? getBrowserUtilitySessionId(activeSessionId, tab)
+          : null;
+        return {
+          id: tab,
+          kind,
+          label: getBrowserUtilityLabel(
+            browserSessionId ? browserSessionStates[browserSessionId] : null
+          ),
+        };
       }
       if (kind === 'side-chat') {
         return { id: tab, kind, label: 'Side Chat' };
       }
       return { id: tab, kind, label: workspaceLeaf || 'Terminal' };
     });
-  }, [activeProjectFileTabs, activeSession?.cwd, projectCwd, rightUtilityTabs]);
+  }, [
+    activeProjectFileTabs,
+    activeSession?.cwd,
+    activeSessionId,
+    browserSessionStates,
+    projectCwd,
+    rightUtilityTabs,
+  ]);
 
   const updateProjectFileTabLabel = useCallback((
     tabId: ProjectUtilityPanelTarget,
@@ -509,6 +555,10 @@ export function App() {
 
   const fileUtilityTabs = useMemo(
     () => rightUtilityTabs.filter(isProjectUtilityFileTab),
+    [rightUtilityTabs]
+  );
+  const browserUtilityTabs = useMemo(
+    () => rightUtilityTabs.filter(isProjectUtilityBrowserTab),
     [rightUtilityTabs]
   );
 
@@ -927,20 +977,24 @@ export function App() {
               }
             />
           ) : null}
-          {activeSessionId ? (
-            <BrowserPanel
-              embedded
-              sessionId={activeSessionId}
-              collapsed={activeUtilityPanel !== 'browser'}
-              width={rightUtilityPanelWidth}
-              onClose={() => closeRightUtilityTab('browser')}
-              onWidthChange={setRightUtilityPanelWidth}
-              isFullscreen={rightPanelFullscreen === 'browser'}
-              onToggleFullscreen={() =>
-                setRightPanelFullscreen(rightPanelFullscreen === 'browser' ? null : 'browser')
-              }
-            />
-          ) : null}
+          {activeSessionId
+            ? browserUtilityTabs.map((tabId) => (
+                <BrowserPanel
+                  key={tabId}
+                  embedded
+                  sessionId={activeSessionId}
+                  browserSessionId={getBrowserUtilitySessionId(activeSessionId, tabId)}
+                  collapsed={activeUtilityPanel !== 'browser' || activeRightUtilityTab !== tabId}
+                  width={rightUtilityPanelWidth}
+                  onClose={() => closeRightUtilityTab(tabId)}
+                  onWidthChange={setRightUtilityPanelWidth}
+                  isFullscreen={rightPanelFullscreen === 'browser'}
+                  onToggleFullscreen={() =>
+                    setRightPanelFullscreen(rightPanelFullscreen === 'browser' ? null : 'browser')
+                  }
+                />
+              ))
+            : null}
           <RightTerminalPanel
             embedded
             collapsed={activeUtilityPanel !== 'terminal'}
@@ -1216,16 +1270,38 @@ function RightUtilityTabStrip({
   onTogglePanel: () => void;
 }) {
   const items = [
-    { id: 'files' as const, label: 'Files', shortcut: '⌘P', disabled: false },
-    { id: 'side-chat' as const, label: 'Side Chat', shortcut: null, disabled: false },
-    { id: 'browser' as const, label: 'Browser', shortcut: '⌘T', disabled: !browserAvailable },
-    { id: 'review' as const, label: 'Review', shortcut: '⌃⌘G', disabled: false },
-    { id: 'terminal' as const, label: 'Terminal', shortcut: '⌃`', disabled: false },
+    { id: 'files' as const, label: 'Files', shortcut: '⌘P', accelerator: 'CommandOrControl+P', disabled: false },
+    { id: 'side-chat' as const, label: 'Side Chat', shortcut: null, accelerator: null, disabled: false },
+    { id: 'browser' as const, label: 'Browser', shortcut: '⌘T', accelerator: 'CommandOrControl+T', disabled: !browserAvailable },
+    { id: 'review' as const, label: 'Review', shortcut: '⌃⌘G', accelerator: 'Control+CommandOrControl+G', disabled: false },
+    { id: 'terminal' as const, label: 'Terminal', shortcut: '⌃`', accelerator: 'Control+`', disabled: false },
   ];
+
+  const handleOpenMenu = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    const rect = event.currentTarget.getBoundingClientRect();
+    const result = await window.electron.showRightUtilityTabMenu({
+      x: rect.left,
+      y: rect.bottom + 6,
+      items: items.map((item) => ({
+        id: item.id,
+        label: item.label,
+        enabled: !item.disabled,
+        accelerator: item.accelerator,
+      })),
+    });
+    if (!result.ok || !result.id) return;
+    const selected = items.find((item) => item.id === result.id);
+    if (!selected || selected.disabled) return;
+    onOpenTab(
+      selected.id,
+      selected.id === 'files' || selected.id === 'browser' ? { newTab: true } : undefined
+    );
+  };
 
   return (
     <div
-      className="drag-region flex h-10 shrink-0 items-center gap-1 border-b border-[var(--border)] bg-[var(--bg-primary)] px-2"
+      className="drag-region relative z-[120] flex h-10 shrink-0 items-center gap-1 overflow-visible border-b border-[var(--border)] bg-[var(--bg-primary)] px-2"
       // In fullscreen with the sidebar collapsed the strip becomes the topmost
       // bar at the window's left edge, so it must clear the traffic lights.
       style={windowControlsInset ? { paddingLeft: 'var(--app-window-controls-inset-left)' } : undefined}
@@ -1270,48 +1346,15 @@ function RightUtilityTabStrip({
             </div>
           );
         })}
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger asChild>
-            <button
-              type="button"
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-t-[7px] border border-b-0 border-transparent text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-secondary)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
-              title="Open another panel"
-              aria-label="Open another panel"
-            >
-              <Plus className="h-3.5 w-3.5" aria-hidden="true" />
-            </button>
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              align="start"
-              sideOffset={6}
-              className="z-[1000] w-[292px] overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] p-1.5 shadow-[0_18px_42px_rgba(15,23,42,0.18)]"
-            >
-              {items.map((item) => {
-                const Icon = getUtilityTabIcon(item.id);
-                const active = activeTab ? getProjectUtilityTabKind(activeTab) === item.id : false;
-                return (
-                  <DropdownMenu.Item
-                    key={item.id}
-                    disabled={item.disabled}
-                    onSelect={() => onOpenTab(item.id, item.id === 'files' ? { newTab: true } : undefined)}
-                    className={`flex h-9 cursor-pointer select-none items-center gap-2 rounded-lg px-2.5 text-[12px] outline-none transition-colors focus:bg-[var(--bg-tertiary)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50 ${
-                      active ? 'bg-[var(--bg-tertiary)] text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'
-                    }`}
-                  >
-                    <Icon className="h-3.5 w-3.5 shrink-0 text-[var(--text-muted)]" aria-hidden="true" />
-                    <span className="min-w-0 flex-1 truncate">{item.label}</span>
-                    {item.shortcut ? (
-                      <span className="ml-auto font-mono text-[10px] text-[var(--text-muted)]">
-                        {item.shortcut}
-                      </span>
-                    ) : null}
-                  </DropdownMenu.Item>
-                );
-              })}
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
+        <button
+          type="button"
+          onClick={handleOpenMenu}
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-t-[7px] border border-b-0 border-transparent text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-secondary)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+          title="Open another panel"
+          aria-label="Open another panel"
+        >
+          <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
       </div>
 
       <div className="no-drag ml-1 flex h-full shrink-0 translate-y-1 items-center">

--- a/src/ui/components/browser/BrowserPanel.logic.ts
+++ b/src/ui/components/browser/BrowserPanel.logic.ts
@@ -1,11 +1,9 @@
-// Address bar sync rules and navigation suggestions for the in-app browser.
+// Address bar sync rules and navigation normalization for the in-app browser.
 // Ported from dpcode (Emanuele-web04/dpcode) BrowserPanel.logic.ts.
 
 import type { BrowserTabState } from '../../../shared/browser-types';
-import type { BrowserHistoryEntry } from '../../store/useBrowserStateStore';
 
 const ABOUT_BLANK_URL = 'about:blank';
-const BROWSER_SUGGESTION_LIMIT = 6;
 const SEARCH_URL_PREFIX = 'https://www.google.com/search?q=';
 
 interface ResolveBrowserAddressSyncInput {
@@ -20,23 +18,6 @@ interface ResolveBrowserAddressSyncInput {
 type BrowserAddressSyncDecision =
   | { type: 'keep' }
   | { type: 'replace'; value: string; syncedValue: string | undefined };
-
-export interface BrowserAddressSuggestion {
-  id: string;
-  kind: 'navigate' | 'tab' | 'history';
-  title: string;
-  detail: string;
-  url: string;
-  tabId?: string;
-  faviconUrl?: string | null;
-}
-
-interface BuildBrowserAddressSuggestionsInput {
-  query: string;
-  activeTabId: string | null;
-  tabs: Array<Pick<BrowserTabState, 'id' | 'title' | 'url' | 'faviconUrl' | 'lastCommittedUrl'>>;
-  recentHistory: BrowserHistoryEntry[];
-}
 
 export interface BrowserChromeStatus {
   tone: 'default' | 'error';
@@ -93,81 +74,6 @@ export function normalizeBrowserAddressInput(input: string): string {
   return `${SEARCH_URL_PREFIX}${encodeURIComponent(trimmed)}`;
 }
 
-function normalizeQuery(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-function displaySuggestionUrl(value: string): string {
-  return value.trim().replace(/^about:blank$/i, '');
-}
-
-function suggestionMatches(query: string, candidate: string): boolean {
-  if (query.length === 0) return true;
-  return normalizeQuery(candidate).includes(query);
-}
-
-function pushSuggestion(
-  suggestions: BrowserAddressSuggestion[],
-  seenUrls: Set<string>,
-  suggestion: BrowserAddressSuggestion
-): void {
-  if (suggestions.length >= BROWSER_SUGGESTION_LIMIT || seenUrls.has(suggestion.url)) return;
-  seenUrls.add(suggestion.url);
-  suggestions.push(suggestion);
-}
-
-export function buildBrowserAddressSuggestions(
-  input: BuildBrowserAddressSuggestionsInput
-): BrowserAddressSuggestion[] {
-  const query = normalizeQuery(input.query);
-  const suggestions: BrowserAddressSuggestion[] = [];
-  const seenUrls = new Set<string>();
-  const directTarget = normalizeBrowserAddressInput(input.query);
-
-  if (query.length > 0) {
-    const directTitle = directTarget.startsWith(SEARCH_URL_PREFIX)
-      ? `Search the web for "${input.query.trim()}"`
-      : `Open ${directTarget}`;
-    pushSuggestion(suggestions, seenUrls, {
-      id: `direct:${directTarget}`,
-      kind: 'navigate',
-      title: directTitle,
-      detail: directTarget,
-      url: directTarget,
-    });
-  }
-
-  for (const tab of input.tabs) {
-    const tabUrl = displaySuggestionUrl(tab.lastCommittedUrl ?? tab.url);
-    if (tabUrl.length === 0 || tab.id === input.activeTabId) continue;
-    if (!suggestionMatches(query, `${tab.title} ${tabUrl}`)) continue;
-    pushSuggestion(suggestions, seenUrls, {
-      id: `tab:${tab.id}`,
-      kind: 'tab',
-      title: tab.title || tabUrl,
-      detail: tabUrl,
-      url: tabUrl,
-      tabId: tab.id,
-      faviconUrl: tab.faviconUrl,
-    });
-  }
-
-  for (const entry of input.recentHistory) {
-    const entryUrl = displaySuggestionUrl(entry.url);
-    if (entryUrl.length === 0) continue;
-    if (!suggestionMatches(query, `${entry.title} ${entryUrl}`)) continue;
-    pushSuggestion(suggestions, seenUrls, {
-      id: `history:${entry.url}`,
-      kind: 'history',
-      title: entry.title || entryUrl,
-      detail: entryUrl,
-      url: entryUrl,
-    });
-  }
-
-  return suggestions.slice(0, BROWSER_SUGGESTION_LIMIT);
-}
-
 export function resolveBrowserChromeStatus(input: {
   localError: string | null;
   sessionLastError: string | null | undefined;
@@ -180,11 +86,11 @@ export function resolveBrowserChromeStatus(input: {
   if (!input.hasActiveTab) {
     return {
       tone: 'default',
-      label: input.workspaceReady ? 'No tabs open' : 'Starting browser...',
+      label: input.workspaceReady ? 'No page open' : 'Starting browser...',
     };
   }
   if (input.activeTabStatus === 'suspended') {
-    return { tone: 'default', label: 'Restoring tab...' };
+    return { tone: 'default', label: 'Restoring page...' };
   }
   return null;
 }

--- a/src/ui/components/browser/BrowserPanel.tsx
+++ b/src/ui/components/browser/BrowserPanel.tsx
@@ -30,12 +30,10 @@ import {
   Camera,
   Copy,
   FileText,
-  Globe,
   Loader2,
   Maximize2,
   Minimize2,
   MoreHorizontal,
-  Plus,
   RefreshCw,
   X,
 } from '../icons';
@@ -50,13 +48,11 @@ import type { Attachment } from '../../../shared/types';
 import { useAppStore } from '../../store/useAppStore';
 import {
   useBrowserStateStore,
-  type BrowserHistoryEntry,
   type PersistedBrowserTab,
   type PersistedSessionBrowserState,
 } from '../../store/useBrowserStateStore';
 import {
   browserAddressDisplayValue,
-  buildBrowserAddressSuggestions,
   normalizeBrowserAddressInput,
   resolveBrowserAddressSync,
   resolveBrowserChromeStatus,
@@ -68,14 +64,9 @@ const DEFAULT_HOME_URL = 'about:blank';
 const READOUT_TEXT_CHAR_LIMIT = 6000;
 const READOUT_LINK_LIMIT = 15;
 
-// Stable empty-array reference so Zustand selectors can return a consistent
-// snapshot when no history exists for a session. Returning `[]` inline would
-// create a fresh array each render and trip React's
-// "getSnapshot should be cached" infinite-loop guard.
-const EMPTY_HISTORY: readonly BrowserHistoryEntry[] = Object.freeze([]);
-
 interface BrowserPanelProps {
   sessionId: string;
+  browserSessionId?: string;
   collapsed: boolean;
   width: number;
   onClose: () => void;
@@ -125,6 +116,7 @@ function stateToPersisted(state: SessionBrowserState): PersistedSessionBrowserSt
 
 export function BrowserPanel({
   sessionId,
+  browserSessionId: browserSessionIdProp,
   collapsed,
   width,
   onClose,
@@ -134,22 +126,20 @@ export function BrowserPanel({
   topInset = 0,
   embedded = false,
 }: BrowserPanelProps) {
+  const browserSessionId = browserSessionIdProp ?? sessionId;
   const requestChatInjection = useAppStore((s) => s.requestChatInjection);
 
   const cachedSessionState = useBrowserStateStore(
-    (s) => s.sessionStatesBySessionId[sessionId] ?? null
+    (s) => s.sessionStatesBySessionId[browserSessionId] ?? null
   );
   const upsertSessionState = useBrowserStateStore((s) => s.upsertSessionState);
   const removeSessionState = useBrowserStateStore((s) => s.removeSessionState);
-  const recentHistory = useBrowserStateStore(
-    (s) => s.recentHistoryBySessionId[sessionId] ?? EMPTY_HISTORY
-  ) as BrowserHistoryEntry[];
   const recordHistoryEntry = useBrowserStateStore((s) => s.recordHistoryEntry);
 
   const [sessionState, setSessionState] = useState<SessionBrowserState>(() => {
     if (cachedSessionState) return persistedToState(cachedSessionState);
     return {
-      sessionId,
+      sessionId: browserSessionId,
       open: false,
       activeTabId: null,
       tabs: [],
@@ -181,7 +171,7 @@ export function BrowserPanel({
     const api = window.electron.browser;
 
     api
-      .open({ sessionId, initialUrl: DEFAULT_HOME_URL })
+      .open({ sessionId: browserSessionId, initialUrl: DEFAULT_HOME_URL })
       .then((state) => {
         if (cancelled) return;
         setSessionState(state);
@@ -192,12 +182,12 @@ export function BrowserPanel({
       });
 
     const dispose = api.onState((nextState) => {
-      if (nextState.sessionId !== sessionId) return;
+      if (nextState.sessionId !== browserSessionId) return;
       setSessionState(nextState);
       upsertSessionState(stateToPersisted(nextState));
       const active = nextState.tabs.find((tab) => tab.id === nextState.activeTabId);
       if (active && active.url && active.url !== DEFAULT_HOME_URL) {
-        recordHistoryEntry(sessionId, {
+        recordHistoryEntry(browserSessionId, {
           url: active.url,
           title: active.title,
           faviconUrl: active.faviconUrl,
@@ -210,21 +200,21 @@ export function BrowserPanel({
       cancelled = true;
       dispose();
     };
-  }, [collapsed, recordHistoryEntry, sessionId, upsertSessionState]);
+  }, [browserSessionId, collapsed, recordHistoryEntry, upsertSessionState]);
 
   // Pane is hidden but we keep the state alive; tell main to detach.
   useEffect(() => {
     if (!collapsed) return;
-    window.electron.browser.hide({ sessionId }).catch(() => {
+    window.electron.browser.hide({ sessionId: browserSessionId }).catch(() => {
       // non-fatal
     });
-  }, [collapsed, sessionId]);
+  }, [browserSessionId, collapsed]);
 
   // ===== Context menu -> send selection to chat =====
   useEffect(() => {
     const api = window.electron.browser;
     const dispose = api.onSendSelection((event: BrowserSendSelectionEvent) => {
-      if (event.sessionId !== sessionId) return;
+      if (event.sessionId !== browserSessionId) return;
       const quoted = event.selectionText
         .split('\n')
         .map((line) => `> ${line}`)
@@ -239,7 +229,7 @@ export function BrowserPanel({
       toast.success('Selection sent to chat');
     });
     return () => dispose();
-  }, [requestChatInjection, sessionId]);
+  }, [browserSessionId, requestChatInjection, sessionId]);
 
   // ===== 地址栏同步 =====
   const nextDisplayValue = browserAddressDisplayValue(activeTab);
@@ -264,24 +254,6 @@ export function BrowserPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionState.activeTabId, nextDisplayValue]);
 
-  const addressSuggestions = useMemo(() => {
-    if (!addressEditing) return [];
-    return buildBrowserAddressSuggestions({
-      query: addressValue,
-      activeTabId: sessionState.activeTabId,
-      tabs: sessionState.tabs,
-      recentHistory,
-    });
-  }, [addressEditing, addressValue, sessionState.tabs, sessionState.activeTabId, recentHistory]);
-
-  // The address suggestions dropdown is a DOM overlay; the native WebContentsView
-  // is always composited on top of the DOM, so the dropdown can only render over
-  // the chrome strip — where it would otherwise cover the tab bar and the "+"
-  // button, swallowing real clicks. While the dropdown is open we detach the
-  // native view (browser.hide) so the dropdown can render over the now-empty
-  // content area, and reattach it when the dropdown closes.
-  const overlayActive = addressEditing && addressSuggestions.length > 0;
-
   const chromeStatus = useMemo(
     () =>
       resolveBrowserChromeStatus({
@@ -299,15 +271,13 @@ export function BrowserPanel({
   const rafRef = useRef<number | null>(null);
 
   const pushBounds = useCallback(() => {
-    // Skip while the suggestions overlay is open — reattaching the native view
-    // here would re-cover the dropdown.
-    if (collapsed || overlayActive) return;
+    if (collapsed) return;
     const el = viewportRef.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
     window.electron.browser
       .setPanelBounds({
-        sessionId,
+        sessionId: browserSessionId,
         bounds: {
           x: Math.round(rect.left),
           y: Math.round(rect.top),
@@ -316,7 +286,7 @@ export function BrowserPanel({
         },
       })
       .catch(() => {});
-  }, [collapsed, overlayActive, sessionId]);
+  }, [browserSessionId, collapsed]);
 
   useLayoutEffect(() => {
     pushBounds();
@@ -362,26 +332,13 @@ export function BrowserPanel({
     };
   }, [collapsed, width, pushBounds]);
 
-  // Detach the native view while the suggestions overlay is open so the dropdown
-  // renders over the content area instead of being hidden behind the web page;
-  // reattach (via pushBounds) once it closes. Reattaching an already-live tab
-  // does not reload it.
-  useEffect(() => {
-    if (collapsed) return;
-    if (overlayActive) {
-      window.electron.browser.hide({ sessionId }).catch(() => {});
-    } else {
-      pushBounds();
-    }
-  }, [overlayActive, collapsed, sessionId, pushBounds]);
-
   // ===== 操作封装 =====
   const handleNavigate = useCallback(
     async (rawInput: string) => {
       const normalized = normalizeBrowserAddressInput(rawInput);
       try {
         const next = await window.electron.browser.navigate({
-          sessionId,
+          sessionId: browserSessionId,
           tabId: sessionState.activeTabId ?? undefined,
           url: normalized,
         });
@@ -392,7 +349,7 @@ export function BrowserPanel({
         setLocalError(String(error));
       }
     },
-    [sessionId, sessionState.activeTabId]
+    [browserSessionId, sessionState.activeTabId]
   );
 
   const handleAddressKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -414,18 +371,12 @@ export function BrowserPanel({
     }
   };
 
-  const handleNewTab = () => {
-    window.electron.browser.newTab({ sessionId, activate: true }).catch((error) => {
-      setLocalError(String(error));
-    });
-  };
-
   const handleCloseBrowser = useCallback(() => {
     window.electron.browser
-      .close({ sessionId })
+      .close({ sessionId: browserSessionId })
       .then((nextState) => {
         setSessionState(nextState);
-        removeSessionState(sessionId);
+        removeSessionState(browserSessionId);
         setAddressDrafts({});
         setLocalError(null);
         onClose();
@@ -435,31 +386,19 @@ export function BrowserPanel({
         setLocalError(message);
         toast.error(`Failed to close browser: ${message}`);
       });
-  }, [onClose, removeSessionState, sessionId]);
-
-  const handleCloseTab = (tabId: string) => {
-    window.electron.browser.closeTab({ sessionId, tabId }).catch((error) => {
-      setLocalError(String(error));
-    });
-  };
-
-  const handleSelectTab = (tabId: string) => {
-    window.electron.browser.selectTab({ sessionId, tabId }).catch((error) => {
-      setLocalError(String(error));
-    });
-  };
+  }, [browserSessionId, onClose, removeSessionState]);
 
   const handleBack = () => {
     if (!activeTab) return;
-    window.electron.browser.goBack({ sessionId, tabId: activeTab.id }).catch(() => {});
+    window.electron.browser.goBack({ sessionId: browserSessionId, tabId: activeTab.id }).catch(() => {});
   };
   const handleForward = () => {
     if (!activeTab) return;
-    window.electron.browser.goForward({ sessionId, tabId: activeTab.id }).catch(() => {});
+    window.electron.browser.goForward({ sessionId: browserSessionId, tabId: activeTab.id }).catch(() => {});
   };
   const handleReload = () => {
     if (!activeTab) return;
-    window.electron.browser.reload({ sessionId, tabId: activeTab.id }).catch(() => {});
+    window.electron.browser.reload({ sessionId: browserSessionId, tabId: activeTab.id }).catch(() => {});
   };
 
   const handleCaptureScreenshot = async () => {
@@ -467,7 +406,7 @@ export function BrowserPanel({
     setScreenshotBusy(true);
     try {
       const result = await window.electron.browser.capture({
-        sessionId,
+        sessionId: browserSessionId,
         tabId: activeTab.id,
       });
       if (!result.ok || !result.base64) {
@@ -507,7 +446,7 @@ export function BrowserPanel({
     setReadoutBusy(true);
     try {
       const result = await window.electron.browser.readPage({
-        sessionId,
+        sessionId: browserSessionId,
         tabId: activeTab.id,
       });
       if (!result.ok) {
@@ -737,7 +676,7 @@ export function BrowserPanel({
             onClick={() => {
               if (activeTab) {
                 window.electron.browser
-                  .openDevTools({ sessionId, tabId: activeTab.id })
+                  .openDevTools({ sessionId: browserSessionId, tabId: activeTab.id })
                   .catch(() => {});
               }
             }}
@@ -772,93 +711,11 @@ export function BrowserPanel({
           </button>
         </div>
 
-        {/* Tab bar */}
-        <div className="flex items-center gap-1 overflow-x-auto px-2 py-1">
-          {sessionState.tabs.map((tab) => {
-            const isActive = tab.id === sessionState.activeTabId;
-            return (
-              <div
-                key={tab.id}
-                className={`group flex h-7 max-w-[180px] items-center gap-1.5 rounded-md px-2 text-[11px] transition-colors ${
-                  isActive
-                    ? 'bg-[var(--bg-primary)] text-[var(--text-primary)] shadow-[0_0_0_1px_var(--border)]'
-                    : 'text-[var(--text-secondary)] hover:bg-[var(--sidebar-item-hover)] hover:text-[var(--text-primary)]'
-                }`}
-              >
-                <button
-                  type="button"
-                  onClick={() => handleSelectTab(tab.id)}
-                  className="flex min-w-0 flex-1 items-center gap-1.5"
-                  title={tab.title || tab.url}
-                >
-                  {tab.faviconUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={tab.faviconUrl}
-                      alt=""
-                      className="h-3 w-3 flex-shrink-0 rounded-[2px]"
-                    />
-                  ) : (
-                    <Globe className="h-3 w-3 flex-shrink-0 text-[var(--text-muted)]" />
-                  )}
-                  <span className="truncate">{tab.title || tab.url || 'New tab'}</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handleCloseTab(tab.id)}
-                  className="invisible inline-flex h-4 w-4 items-center justify-center rounded-sm text-[var(--text-muted)] group-hover:visible hover:bg-[var(--bg-tertiary)] hover:text-[var(--text-primary)]"
-                  title="Close tab"
-                  aria-label="Close tab"
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </div>
-            );
-          })}
-          <button
-            type="button"
-            onClick={handleNewTab}
-            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-secondary)] transition-colors hover:bg-[var(--sidebar-item-hover)] hover:text-[var(--text-primary)]"
-            title="New tab"
-            aria-label="New tab"
-          >
-            <Plus className="h-[13px] w-[13px]" />
-          </button>
-        </div>
       </div>
 
       {/* Viewport placeholder: main process mirrors the native WebContentsView here */}
       <div className="relative flex-1 min-h-0 bg-[var(--bg-primary)]">
         <div ref={viewportRef} className="absolute inset-0" />
-        {/* Address suggestions render here (over the content area, not the tab
-            bar) so they never cover the "+" button. The native view is detached
-            while this is shown (see overlayActive effect), so the dropdown is
-            visible instead of hidden behind the web page. */}
-        {overlayActive && (
-          <div className="absolute left-2 right-2 top-2 z-30 overflow-hidden rounded-md border border-[var(--border)] bg-[var(--bg-primary)] shadow-lg">
-            {addressSuggestions.map((suggestion) => (
-              <button
-                key={suggestion.id}
-                type="button"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  setAddressEditing(false);
-                  if (suggestion.kind === 'tab' && suggestion.tabId) {
-                    handleSelectTab(suggestion.tabId);
-                  } else {
-                    void handleNavigate(suggestion.url);
-                  }
-                }}
-                className="block w-full px-2 py-1.5 text-left text-[12px] text-[var(--text-primary)] hover:bg-[var(--sidebar-item-hover)]"
-              >
-                <div className="truncate text-[12px] font-medium">{suggestion.title}</div>
-                <div className="truncate text-[11px] text-[var(--text-muted)]">
-                  {suggestion.detail}
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
         {chromeStatus && (
           <div
             className={`pointer-events-none absolute bottom-2 left-2 right-2 rounded-md border px-2 py-1 text-[11px] ${

--- a/src/ui/store/useAppStore.ts
+++ b/src/ui/store/useAppStore.ts
@@ -668,20 +668,32 @@ function normalizeChatPanes(
 }
 
 let rightUtilityFileTabCounter = 0;
+let rightUtilityBrowserTabCounter = 0;
 
 function isRightUtilityFileTab(target: ProjectUtilityPanelTarget | null | undefined): boolean {
   return target === 'files' || Boolean(target?.startsWith('files:'));
 }
 
+function isRightUtilityBrowserTab(target: ProjectUtilityPanelTarget | null | undefined): boolean {
+  return target === 'browser' || Boolean(target?.startsWith('browser:'));
+}
+
 function getRightUtilityTabKind(
   target: ProjectUtilityPanelTarget
 ): ProjectUtilityPanelKind {
-  return isRightUtilityFileTab(target) ? 'files' : target;
+  if (isRightUtilityFileTab(target)) return 'files';
+  if (isRightUtilityBrowserTab(target)) return 'browser';
+  return target;
 }
 
 function createRightUtilityFileTabId(): ProjectUtilityPanelTarget {
   rightUtilityFileTabCounter += 1;
   return `files:${Date.now().toString(36)}-${rightUtilityFileTabCounter}`;
+}
+
+function createRightUtilityBrowserTabId(): ProjectUtilityPanelTarget {
+  rightUtilityBrowserTabCounter += 1;
+  return `browser:${Date.now().toString(36)}-${rightUtilityBrowserTabCounter}`;
 }
 
 function resolveRightUtilityTabOpen(
@@ -700,6 +712,14 @@ function resolveRightUtilityTabOpen(
     };
   }
 
+  if (target === 'browser') {
+    const activeTab = options?.newTab ? createRightUtilityBrowserTabId() : 'browser';
+    return {
+      tabs: tabs.includes(activeTab) ? tabs : [...tabs, activeTab],
+      activeTab,
+    };
+  }
+
   return {
     tabs: tabs.includes(target) ? tabs : [...tabs, target],
     activeTab: target,
@@ -712,6 +732,12 @@ function resolveRightUtilityTabOpenPreservingActive(
   activeTab: ProjectUtilityPanelTarget | null
 ): { tabs: ProjectUtilityPanelTarget[]; activeTab: ProjectUtilityPanelTarget } {
   if (target === 'files' && isRightUtilityFileTab(activeTab)) {
+    return {
+      tabs: addRightUtilityTab(tabs, activeTab),
+      activeTab,
+    };
+  }
+  if (target === 'browser' && isRightUtilityBrowserTab(activeTab)) {
     return {
       tabs: addRightUtilityTab(tabs, activeTab),
       activeTab,
@@ -2216,7 +2242,21 @@ export const useAppStore = create<Store>()(
         activeRightUtilityTab: nextActiveTab,
       };
 
-      if (!nextActiveTab) {
+      if (state.activeRightUtilityTab === target && nextActiveTab) {
+        const nextActiveKind = getRightUtilityTabKind(nextActiveTab);
+        if (nextActiveKind === 'files' || nextActiveKind === 'review') {
+          patch.projectPanelView = nextActiveKind === 'review' ? 'changes' : 'files';
+          patch.projectTreeCollapsed = false;
+          patch.browserPanelOpen = false;
+        } else if (nextActiveKind === 'browser') {
+          patch.projectTreeCollapsed = true;
+          patch.browserPanelOpen = true;
+        } else {
+          patch.projectTreeCollapsed = true;
+          patch.browserPanelOpen = false;
+          patch.rightPanelFullscreen = null;
+        }
+      } else if (!nextActiveTab) {
         patch.projectTreeCollapsed = true;
         patch.browserPanelOpen = false;
         patch.rightPanelFullscreen = null;
@@ -2279,18 +2319,24 @@ export const useAppStore = create<Store>()(
   },
 
   setBrowserPanelOpen: (browserPanelOpen) => {
-    set((state) => ({
-      browserPanelOpen,
-      rightUtilityTabs: browserPanelOpen
-        ? addRightUtilityTab(state.rightUtilityTabs, 'browser')
-        : state.rightUtilityTabs,
-      activeRightUtilityTab: browserPanelOpen ? 'browser' : state.activeRightUtilityTab,
-      rightUtilityPanelHidden: browserPanelOpen ? false : state.rightUtilityPanelHidden,
-      rightPanelFullscreen:
-        !browserPanelOpen && state.rightPanelFullscreen === 'browser'
-          ? null
-          : state.rightPanelFullscreen,
-    }));
+    set((state) => {
+      const activeBrowserTab = isRightUtilityBrowserTab(state.activeRightUtilityTab)
+        ? state.activeRightUtilityTab
+        : null;
+      const browserTab = activeBrowserTab ?? 'browser';
+      return {
+        browserPanelOpen,
+        rightUtilityTabs: browserPanelOpen
+          ? addRightUtilityTab(state.rightUtilityTabs, browserTab)
+          : state.rightUtilityTabs,
+        activeRightUtilityTab: browserPanelOpen ? browserTab : state.activeRightUtilityTab,
+        rightUtilityPanelHidden: browserPanelOpen ? false : state.rightUtilityPanelHidden,
+        rightPanelFullscreen:
+          !browserPanelOpen && state.rightPanelFullscreen === 'browser'
+            ? null
+            : state.rightPanelFullscreen,
+      };
+    });
   },
 
   setRightPanelFullscreen: (target) => {
@@ -2299,8 +2345,15 @@ export const useAppStore = create<Store>()(
         rightPanelFullscreen: 'browser',
         browserPanelOpen: true,
         projectTreeCollapsed: true,
-        rightUtilityTabs: addRightUtilityTab(state.rightUtilityTabs, 'browser'),
-        activeRightUtilityTab: 'browser',
+        rightUtilityTabs: addRightUtilityTab(
+          state.rightUtilityTabs,
+          isRightUtilityBrowserTab(state.activeRightUtilityTab)
+            ? state.activeRightUtilityTab
+            : 'browser'
+        ),
+        activeRightUtilityTab: isRightUtilityBrowserTab(state.activeRightUtilityTab)
+          ? state.activeRightUtilityTab
+          : 'browser',
         rightUtilityPanelHidden: false,
       }));
       return;

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -154,7 +154,10 @@ export type ActiveWorkspace = 'chat' | 'skills' | 'prompts' | 'automations';
 export type ChatSidebarView = 'threads' | 'prompts' | 'skills';
 export type ProjectPanelView = 'files' | 'changes';
 export type ProjectUtilityPanelKind = 'files' | 'side-chat' | 'browser' | 'review' | 'terminal';
-export type ProjectUtilityPanelTarget = ProjectUtilityPanelKind | `files:${string}`;
+export type ProjectUtilityPanelTarget =
+  | ProjectUtilityPanelKind
+  | `files:${string}`
+  | `browser:${string}`;
 export type ProjectUtilityTabDescriptor = {
   id: ProjectUtilityPanelTarget;
   kind: ProjectUtilityPanelKind;

--- a/src/ui/utils/html-preview.ts
+++ b/src/ui/utils/html-preview.ts
@@ -29,9 +29,9 @@ export async function openHtmlFileInBrowserTab({
     return;
   }
 
-  await window.electron.browser.newTab({
+  await window.electron.browser.navigate({
     sessionId,
+    tabId: currentState.activeTabId ?? undefined,
     url: preview.url,
-    activate: true,
   });
 }


### PR DESCRIPTION
## Summary
- replace the React right-panel launcher dropdown with an Electron native popup menu so it renders above Browser WebContentsView
- keep the browser page attached while opening the launcher menu so page content does not blank out
- route separate browser utility tabs through distinct browser session ids and remove obsolete in-panel tab/suggestion UI paths

## Root Cause
The launcher dropdown was rendered in the React DOM, while the in-app browser page is an Electron WebContentsView composited above renderer DOM. Raising z-index cannot place a DOM menu above that native view; temporarily hiding the WebContentsView made the menu visible but blanked the page.

## Validation
- npm run build
- git diff --check