### PR TITLE
✨ feat(session): lock sessions to one agent with context-carrying handoff

### DIFF
--- a/scripts/verify-session-handoff.mjs
+++ b/scripts/verify-session-handoff.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// Verifies the provider-handoff wiring end to end:
+// session lock in the composer -> handoff dialog -> session-handoff IPC
+// (new session + transcript copy + pending flag) -> first-prompt
+// <handoff_context> injection in handleSessionContinue.
+//
+// Also runs a functional pass against the transpiled session-store (electron
+// stubbed, scratch sqlite DB) when the native better-sqlite3 build is loadable
+// from plain Node.
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const root = process.cwd();
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+
+// ---------- static wiring assertions ----------
+
+// Schema + updaters
+const store = read('src/electron/libs/session-store.ts');
+assert.ok(
+  store.includes("ensureColumn('sessions', 'handoff_source_provider', 'TEXT')") &&
+    store.includes("ensureColumn('sessions', 'handoff_pending', 'INTEGER DEFAULT 0')"),
+  'session-store must migrate handoff columns'
+);
+assert.ok(
+  store.includes('export function setSessionHandoff') &&
+    store.includes('export function clearSessionHandoffPending'),
+  'session-store must expose handoff updaters'
+);
+
+// IPC handler: new session for the target provider, transcript copy, pending flag
+const ipc = read('src/electron/ipc-handlers.ts');
+assert.ok(
+  ipc.includes("'session-handoff',") &&
+    ipc.includes('sessions.copySessionHistory(source.id, handoff.id)') &&
+    ipc.includes('sessions.setSessionHandoff(handoff.id, sourceProvider)') &&
+    ipc.includes('buildSessionInfoFromRow(row)'),
+  'session-handoff handler must create the target session, copy the transcript, and mark handoff pending'
+);
+assert.ok(
+  ipc.includes('targetProvider === sourceProvider') &&
+    ipc.includes('there is no conversation to hand off yet'),
+  'session-handoff handler must reject same-provider and empty-transcript handoffs'
+);
+
+// First-prompt injection + one-shot semantics + no double bootstrap
+assert.ok(
+  ipc.includes('buildHandoffContextText({') &&
+    ipc.includes('<handoff_context>') &&
+    ipc.includes('<latest_user_message>') &&
+    ipc.includes('clearSessionHandoffPending(sessionId)'),
+  'handleSessionContinue must inject <handoff_context> around the first prompt and clear the pending flag'
+);
+assert.ok(
+  /!handoffContextText &&\s*\n\s*historyBeforeContinue\.length > 0/.test(ipc),
+  'the Claude history bootstrap must be skipped when handoff context is being injected'
+);
+
+// Bootstrap text shape: earlier summary + recent verbatim within a budget
+assert.ok(
+  ipc.includes('HANDOFF_RECENT_MESSAGE_COUNT') &&
+    ipc.includes('Earlier conversation summary:') &&
+    ipc.includes('Most recent messages:') &&
+    ipc.includes('HANDOFF_CONTEXT_MAX_CHARS'),
+  'buildHandoffContextText must split earlier/recent messages under a char budget'
+);
+
+// SessionInfo surface for the UI badge
+const shared = read('src/shared/types.ts');
+assert.ok(
+  shared.includes('handoffSourceProvider?: AgentProvider | null'),
+  'SessionInfo must expose handoffSourceProvider'
+);
+assert.ok(
+  ipc.includes('handoffSourceProvider: (row.handoff_source_provider'),
+  'buildSessionInfoFromRow must map handoff_source_provider'
+);
+
+// Preload bridge + renderer typing
+const preload = read('src/electron/preload.cts');
+assert.ok(
+  preload.includes('sessionHandoff:') && preload.includes("'session-handoff'"),
+  'preload must expose sessionHandoff over the session-handoff channel'
+);
+assert.ok(
+  read('src/types.d.ts').includes('sessionHandoff: (payload:'),
+  'types.d.ts must declare sessionHandoff'
+);
+
+// Store action: same-pane takeover
+const appStore = read('src/ui/store/useAppStore.ts');
+assert.ok(
+  appStore.includes('handoffSessionToProvider:') &&
+    appStore.includes('window.electron.sessionHandoff(') &&
+    appStore.includes('placeSessionInPane(active.id, view.id)'),
+  'handoffSessionToProvider must call the IPC and take over the focused pane'
+);
+assert.ok(
+  appStore.includes('handoffSourceProvider: info.handoffSourceProvider'),
+  'freshSessionViewFromInfo must carry handoffSourceProvider to the SessionView'
+);
+
+// Composer: provider lock + dialog instead of silent switch
+const promptInput = read('src/ui/components/PromptInput.tsx');
+assert.ok(
+  promptInput.includes('sessionProviderLocked') &&
+    promptInput.includes('setHandoffTarget(nextProvider)') &&
+    promptInput.includes('onAgentChange={handleAgentChange}'),
+  'PromptInput must intercept provider switches on locked sessions'
+);
+assert.ok(
+  promptInput.includes('Hand off to') && promptInput.includes('handoffSessionToProvider('),
+  'PromptInput must render the handoff confirm dialog wired to the store action'
+);
+assert.ok(
+  promptInput.includes('Handoff from {providerLabel(activeSession.handoffSourceProvider)}'),
+  'PromptInput must show the handoff-source badge'
+);
+
+console.log('static wiring assertions passed');
+
+// ---------- functional pass (transpiled session-store, electron stubbed) ----------
+
+const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-handoff-verify-'));
+const require2 = createRequire(import.meta.url);
+const Module = require2('module');
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, ...rest) {
+  if (request === 'electron') {
+    return { app: { getPath: () => scratchDir } };
+  }
+  return originalLoad.call(this, request, ...rest);
+};
+
+let sessionsLib;
+try {
+  sessionsLib = require2(path.join(root, 'dist-electron/electron/libs/session-store.js'));
+  sessionsLib.initialize();
+} catch (error) {
+  console.log(`functional pass SKIPPED (session-store not loadable in plain Node): ${error.message}`);
+  process.exit(0);
+}
+
+try {
+  const source = sessionsLib.createSession({
+    title: 'Handoff verify',
+    cwd: scratchDir,
+    provider: 'claude',
+  });
+  sessionsLib.addMessage(source.id, {
+    type: 'user_prompt',
+    prompt: 'Please add a retry helper to http.ts',
+    createdAt: Date.now(),
+  });
+
+  // Simulate the IPC handler's session-side effects.
+  const handoff = sessionsLib.createSession({
+    title: source.title,
+    cwd: scratchDir,
+    provider: 'codex',
+  });
+  sessionsLib.copySessionHistory(source.id, handoff.id);
+  sessionsLib.setSessionHandoff(handoff.id, 'claude');
+
+  const row = sessionsLib.getSession(handoff.id);
+  assert.equal(row.provider, 'codex', 'handoff session must be created for the target provider');
+  assert.equal(row.handoff_source_provider, 'claude', 'source provider must be persisted');
+  assert.equal(row.handoff_pending, 1, 'handoff must start pending');
+  assert.equal(
+    row.claude_session_id ?? null,
+    null,
+    'handoff session must not inherit any provider resume id'
+  );
+  const history = sessionsLib.getSessionHistory(handoff.id);
+  assert.ok(
+    history.some((m) => m.type === 'user_prompt' && m.prompt.includes('retry helper')),
+    'transcript must be copied into the handoff session'
+  );
+
+  sessionsLib.clearSessionHandoffPending(handoff.id);
+  assert.equal(
+    sessionsLib.getSession(handoff.id).handoff_pending,
+    0,
+    'pending flag must clear after the first prompt'
+  );
+
+  console.log('functional session-store pass passed');
+} finally {
+  Module._load = originalLoad;
+  fs.rmSync(scratchDir, { recursive: true, force: true });
+}
+
+console.log('verify-session-handoff: all checks passed');

--- a/src/electron/ipc-handlers.ts
+++ b/src/electron/ipc-handlers.ts
@@ -1881,6 +1881,84 @@ function buildHistoryTranscript(history: StreamMessage[]): string {
   return entries.join('\n\n').trim();
 }
 
+// Provider-handoff bootstrap (ported from synara's thread handoff): the first
+// prompt of a handoff session carries the imported transcript — recent turns
+// nearly verbatim, earlier turns as one-line bullets — inside a char budget.
+const HANDOFF_RECENT_MESSAGE_COUNT = 6;
+const HANDOFF_EARLIER_MESSAGE_CHAR_LIMIT = 320;
+const HANDOFF_RECENT_MESSAGE_CHAR_LIMIT = 2_400;
+const HANDOFF_CONTEXT_MAX_CHARS = 24_000;
+
+function truncateHandoffText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+}
+
+function collectHandoffTranscriptEntries(
+  history: StreamMessage[]
+): Array<{ role: 'User' | 'Assistant'; text: string }> {
+  const entries: Array<{ role: 'User' | 'Assistant'; text: string }> = [];
+  for (const message of history) {
+    if (message.type === 'user_prompt') {
+      const prompt = message.prompt.trim();
+      if (prompt) {
+        entries.push({ role: 'User', text: prompt });
+      }
+      continue;
+    }
+    const assistantText = extractAssistantText(message);
+    if (assistantText && !isLocalUtilityAssistantText(assistantText)) {
+      entries.push({ role: 'Assistant', text: assistantText });
+    }
+  }
+  return entries;
+}
+
+function buildHandoffContextText(params: {
+  history: StreamMessage[];
+  title: string;
+  sourceProvider: string;
+  maxChars?: number;
+}): string | null {
+  const entries = collectHandoffTranscriptEntries(params.history);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const earlier = entries.slice(0, -HANDOFF_RECENT_MESSAGE_COUNT);
+  const recent = entries.slice(-HANDOFF_RECENT_MESSAGE_COUNT);
+  const sections: string[] = [
+    `This conversation was handed off from ${params.sourceProvider}. Continue the work with full awareness of the context below.`,
+    `Original conversation title: ${params.title}`,
+  ];
+
+  if (earlier.length > 0) {
+    sections.push(
+      'Earlier conversation summary:\n' +
+        earlier
+          .map(
+            (entry) =>
+              `- ${entry.role}: ${truncateHandoffText(entry.text.replace(/\s+/g, ' ').trim(), HANDOFF_EARLIER_MESSAGE_CHAR_LIMIT)}`
+          )
+          .join('\n')
+    );
+  }
+
+  sections.push(
+    'Most recent messages:\n' +
+      recent
+        .map(
+          (entry) => `${entry.role}:\n${truncateHandoffText(entry.text.trim(), HANDOFF_RECENT_MESSAGE_CHAR_LIMIT)}`
+        )
+        .join('\n\n')
+  );
+
+  const joined = sections.join('\n\n').trim();
+  return truncateHandoffText(joined, Math.max(0, params.maxChars ?? HANDOFF_CONTEXT_MAX_CHARS));
+}
+
 function buildLatestEditSummaryPrompt(history: StreamMessage[]): string {
   const transcript = buildHistoryTranscript(history);
   const lines = [
@@ -4166,6 +4244,69 @@ export function setupIPCHandlers(mainWindow: BrowserWindow): void {
   ipcMainHandle('fork-session', async (_event, sourceSessionId: string) => {
     return forkSessionInternal(sourceSessionId);
   });
+
+  // Provider handoff: sessions are locked to one agent; switching creates a
+  // new session for the target provider that imports the transcript and
+  // injects it as context on the first prompt (synara-style thread handoff).
+  ipcMainHandle(
+    'session-handoff',
+    async (
+      _event,
+      payload: { sessionId: string; targetProvider: AgentProvider }
+    ): Promise<{ ok: true; session: SessionInfo } | { ok: false; message: string }> => {
+      try {
+        const source = sessions.getSession(payload?.sessionId || '');
+        if (!source) {
+          return { ok: false as const, message: 'Session not found.' };
+        }
+        const sourceProvider = (source.provider || 'claude') as AgentProvider;
+        const targetProvider = payload?.targetProvider;
+        if (!targetProvider || targetProvider === sourceProvider) {
+          return { ok: false as const, message: 'Pick a different agent to hand off to.' };
+        }
+        const history = sessions.getSessionHistory(source.id);
+        if (collectHandoffTranscriptEntries(history).length === 0) {
+          return {
+            ok: false as const,
+            message: 'Send a message first — there is no conversation to hand off yet.',
+          };
+        }
+
+        const handoff = sessions.createSession({
+          title: source.title,
+          cwd: source.cwd || undefined,
+          projectCwd: source.project_cwd ?? source.cwd ?? null,
+          envMode: source.env_mode === 'worktree' ? 'worktree' : 'local',
+          worktreePath: source.worktree_path ?? null,
+          associatedWorktreePath: source.associated_worktree_path ?? null,
+          associatedWorktreeBranch: source.associated_worktree_branch ?? null,
+          associatedWorktreeRef: source.associated_worktree_ref ?? null,
+          provider: targetProvider,
+          scope: normalizeSessionScope(source.conversation_scope),
+          agentId: source.agent_id || null,
+          channelId: normalizeWorkspaceChannelId(source.workspace_channel_id),
+          teamMode: normalizeSessionTeamMode(source.team_mode),
+          teamId: source.team_id || null,
+        });
+
+        // Copy the transcript so the handoff pane shows the conversation; the
+        // pending flag makes the first prompt carry it as <handoff_context>.
+        sessions.copySessionHistory(source.id, handoff.id);
+        sessions.setSessionHandoff(handoff.id, sourceProvider);
+
+        const row = sessions.getSession(handoff.id);
+        if (!row) {
+          return { ok: false as const, message: 'Failed to read the handoff session.' };
+        }
+        return { ok: true as const, session: buildSessionInfoFromRow(row) };
+      } catch (error) {
+        return {
+          ok: false as const,
+          message: error instanceof Error ? error.message : 'Failed to create the handoff session.',
+        };
+      }
+    }
+  );
 
   // Claude rewind: restore files (SDK checkpoint) and/or truncate the
   // conversation back to the state before a given user message ran.
@@ -6696,6 +6837,7 @@ function buildSessionInfoFromRow(
     channelId: normalizeWorkspaceChannelId(row.workspace_channel_id),
     teamMode: normalizeSessionTeamMode(row.team_mode),
     teamId: row.team_id || null,
+    handoffSourceProvider: (row.handoff_source_provider as AgentProvider | null) || null,
     latestClaudeModelUsage,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -7218,6 +7360,22 @@ async function handleSessionContinue(
   if (planImplementationPrompt) {
     effectiveRunnerPrompt = planImplementationPrompt;
   }
+  // First prompt of a provider-handoff session: inject the imported transcript
+  // so the new agent starts with the prior conversation's context.
+  const handoffContextText =
+    session.handoff_pending === 1
+      ? buildHandoffContextText({
+          history: historyBeforeContinue,
+          title: session.title,
+          sourceProvider: session.handoff_source_provider || previousProvider,
+        })
+      : null;
+  if (handoffContextText) {
+    effectiveRunnerPrompt = `<handoff_context>\n${handoffContextText}\n</handoff_context>\n\n<latest_user_message>\n${effectiveRunnerPrompt}\n</latest_user_message>`;
+  }
+  if (session.handoff_pending === 1) {
+    sessions.clearSessionHandoffPending(sessionId);
+  }
   const runnerPrompt = augmentPromptForLiveWidgetProtocol(
     await buildRunnerPromptWithMemory(nextProvider, effectiveRunnerPrompt, session.cwd || undefined),
     historyBeforeContinue
@@ -7522,6 +7680,9 @@ async function handleSessionContinue(
     nextProvider === 'claude' &&
     !providerChanged &&
     !nextResumeSessionId &&
+    // A pending handoff carries the transcript inside the prompt itself; the
+    // copied history must not also be replayed into a bootstrap session.
+    !handoffContextText &&
     historyBeforeContinue.length > 0
   ) {
     try {

--- a/src/electron/libs/session-store.ts
+++ b/src/electron/libs/session-store.ts
@@ -561,6 +561,8 @@ export function initialize(): void {
   ensureColumn('sessions', 'associated_worktree_path', 'TEXT');
   ensureColumn('sessions', 'associated_worktree_branch', 'TEXT');
   ensureColumn('sessions', 'associated_worktree_ref', 'TEXT');
+  ensureColumn('sessions', 'handoff_source_provider', 'TEXT');
+  ensureColumn('sessions', 'handoff_pending', 'INTEGER DEFAULT 0');
   ensureColumn('messages', 'message_type', 'TEXT');
   ensureColumn('messages', 'source_origin', 'TEXT');
   ensureColumn('messages', 'search_text', 'TEXT');
@@ -1620,6 +1622,24 @@ export function sweepOrphanRunningSessions(): number {
     .prepare("UPDATE sessions SET status = 'error', updated_at = ? WHERE status = 'running'")
     .run(Date.now());
   return result.changes;
+}
+
+// Mark a session as created via provider handoff; pending means the first
+// prompt still needs the imported-transcript context injected.
+export function setSessionHandoff(sessionId: string, sourceProvider: string): void {
+  const now = Date.now();
+  const stmt = getDb().prepare(`
+    UPDATE sessions SET handoff_source_provider = ?, handoff_pending = 1, updated_at = ? WHERE id = ?
+  `);
+  stmt.run(sourceProvider, now, sessionId);
+}
+
+export function clearSessionHandoffPending(sessionId: string): void {
+  const now = Date.now();
+  const stmt = getDb().prepare(`
+    UPDATE sessions SET handoff_pending = 0, updated_at = ? WHERE id = ?
+  `);
+  stmt.run(now, sessionId);
 }
 
 // 更新 Claude Session ID

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -200,6 +200,10 @@ contextBridge.exposeInMainWorld('electron', {
     return ipcRenderer.invoke('generate-session-title', prompt);
   },
 
+  sessionHandoff: (payload: { sessionId: string; targetProvider: string }) => {
+    return ipcRenderer.invoke('session-handoff', payload);
+  },
+
   forkSession: (sessionId: string) => {
     return ipcRenderer.invoke('fork-session', sessionId);
   },

--- a/src/electron/types.ts
+++ b/src/electron/types.ts
@@ -51,6 +51,8 @@ export interface SessionRow {
   associated_worktree_path: string | null;
   associated_worktree_branch: string | null;
   associated_worktree_ref: string | null;
+  handoff_source_provider: string | null;
+  handoff_pending: number | null;
   allowed_tools: string | null;
   last_prompt: string | null;
   todo_state: string | null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1068,6 +1068,8 @@ export interface SessionInfo {
   channelId?: string;
   teamMode?: SessionTeamMode;
   teamId?: string | null;
+  /** Set when this session was created by handing off from another agent. */
+  handoffSourceProvider?: AgentProvider | null;
   latestClaudeModelUsage?: LatestClaudeModelUsage;
   createdAt: number;
   updatedAt: number;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -105,6 +105,10 @@ declare global {
     forkSession: (
       sessionId: string
     ) => Promise<{ ok: boolean; session?: SessionInfo; message?: string }>;
+    sessionHandoff: (payload: {
+      sessionId: string;
+      targetProvider: import('./shared/types').AgentProvider;
+    }) => Promise<{ ok: boolean; session?: SessionInfo; message?: string }>;
     claudeRewind: (
       input: import('./shared/types').ClaudeRewindInput
     ) => Promise<import('./shared/types').ClaudeRewindResult>;

--- a/src/ui/components/PromptInput.tsx
+++ b/src/ui/components/PromptInput.tsx
@@ -21,6 +21,9 @@ import { ClaudeContextIndicator } from './ClaudeContextIndicator';
 import { CodexContextIndicator } from './CodexContextIndicator';
 import { OpenCodeContextIndicator } from './OpenCodeContextIndicator';
 import { ComposerAgentModelPicker } from './ComposerAgentControls';
+import * as Dialog from './ui/dialog';
+import { PROVIDERS } from '../utils/provider';
+import type { AgentProvider } from '../types';
 import { ClaudePermissionModePicker } from './ClaudePermissionModePicker';
 import { CodexPermissionModePicker } from './CodexPermissionModePicker';
 import { KimiPermissionModePicker } from './KimiPermissionModePicker';
@@ -93,6 +96,7 @@ export function PromptInput({
     pendingChatInjection,
     consumeChatInjection,
     draftStartMode,
+    handoffSessionToProvider,
   } = useAppStore();
   const [prompt, setPrompt] = useState('');
   const [attachments, setAttachments] = useState<Attachment[]>([]);
@@ -116,6 +120,46 @@ export function PromptInput({
   });
   const runtimeProvider = agentSelection.provider;
   const selectedModel = agentSelection.model;
+
+  // Sessions are locked to their agent once a conversation exists — switching
+  // goes through an explicit handoff that carries the transcript to a new
+  // session for the target provider (synara-style thread handoff).
+  const [handoffTarget, setHandoffTarget] = useState<AgentProvider | null>(null);
+  const [handoffBusy, setHandoffBusy] = useState(false);
+  const sessionProviderLocked = Boolean(
+    activeSession &&
+      !activeSession.isDraft &&
+      !activeSession.readOnly &&
+      activeSession.provider &&
+      (activeSession.messages.length > 0 || activeSession.hydrated === false)
+  );
+  const handleAgentChange = useCallback(
+    (nextProvider: AgentProvider) => {
+      if (sessionProviderLocked && activeSession?.provider && nextProvider !== activeSession.provider) {
+        setHandoffTarget(nextProvider);
+        return;
+      }
+      agentSelection.selectAgent(nextProvider);
+    },
+    [activeSession?.provider, agentSelection, sessionProviderLocked]
+  );
+  const confirmHandoff = useCallback(async () => {
+    if (!activeSession || !handoffTarget || handoffBusy) {
+      return;
+    }
+    setHandoffBusy(true);
+    try {
+      await handoffSessionToProvider(activeSession.id, handoffTarget);
+      setHandoffTarget(null);
+    } finally {
+      setHandoffBusy(false);
+    }
+  }, [activeSession, handoffBusy, handoffSessionToProvider, handoffTarget]);
+  const providerLabel = useCallback(
+    (provider: AgentProvider | null | undefined) =>
+      PROVIDERS.find((entry) => entry.id === provider)?.label || provider || 'the agent',
+    []
+  );
   const selectedModelLabel = agentSelection.selectedModelLabel;
   const modelSetupRequired = Boolean(agentSelection.modelSetup);
   const isClaudeContextVisible = runtimeProvider === 'claude' && activeSession?.provider === 'claude';
@@ -715,6 +759,57 @@ export function PromptInput({
   return (
     <div className="bg-transparent">
       <div className="mx-auto max-w-4xl">
+        {activeSession?.handoffSourceProvider ? (
+          <div className="mb-2 flex items-center gap-2 px-1 text-[11.5px] text-[var(--text-muted)]">
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--accent)]" aria-hidden="true" />
+            <span className="min-w-0 truncate">
+              Handoff from {providerLabel(activeSession.handoffSourceProvider)}
+            </span>
+          </div>
+        ) : null}
+        <Dialog.Root
+          open={handoffTarget !== null}
+          onOpenChange={(open) => {
+            if (!open && !handoffBusy) {
+              setHandoffTarget(null);
+            }
+          }}
+        >
+          <Dialog.Portal>
+            <Dialog.Overlay className="fixed inset-0 z-[110] bg-black/50" />
+            <Dialog.Content className="fixed top-1/2 left-1/2 z-[120] w-[420px] -translate-x-1/2 -translate-y-1/2 rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] p-6 shadow-xl">
+              <Dialog.Title className="mb-3 text-lg font-semibold">
+                Hand off to {providerLabel(handoffTarget)}?
+              </Dialog.Title>
+              <Dialog.Description className="mb-5 text-sm leading-relaxed text-[var(--text-secondary)]">
+                This conversation is locked to {providerLabel(activeSession?.provider)}. Handing off
+                creates a new session for {providerLabel(handoffTarget)} that carries the
+                conversation over — your next message will include the context so the new agent can
+                continue the work.
+              </Dialog.Description>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  disabled={handoffBusy}
+                  onClick={() => setHandoffTarget(null)}
+                  className="rounded-md border border-[var(--border)] px-3 py-1.5 text-sm text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-tertiary)] disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={handoffBusy}
+                  onClick={() => {
+                    void confirmHandoff();
+                  }}
+                  className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+                >
+                  {handoffBusy ? 'Handing off…' : 'Hand off'}
+                </button>
+              </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
         <div className={composerOuterClass}>
           {projectFileMentions.hasMentionQuery ? (
             <div className="absolute inset-x-0 bottom-full z-40">
@@ -802,7 +897,7 @@ export function PromptInput({
                 modelValue={selectedModel}
                 allAgentModelOptions={agentSelection.allAgentModelOptions}
                 disabled={isBusy}
-                onAgentChange={agentSelection.selectAgent}
+                onAgentChange={handleAgentChange}
                 onModelChange={agentSelection.selectModel}
                 codexModels={agentSelection.codexModels.length > 0 ? agentSelection.codexModels : undefined}
                 claudeReasoningEffort={agentSelection.claudeReasoningEffort ?? undefined}

--- a/src/ui/store/useAppStore.ts
+++ b/src/ui/store/useAppStore.ts
@@ -530,6 +530,7 @@ function freshSessionViewFromInfo(info: import('../shared/types').SessionInfo): 
     channelId: normalizeWorkspaceChannelId(info.channelId),
     teamMode: normalizeSessionTeamMode(info.teamMode),
     teamId: info.teamId || null,
+    handoffSourceProvider: info.handoffSourceProvider || null,
     latestClaudeModelUsage: info.latestClaudeModelUsage,
     messages: [],
     hydrated: false,
@@ -1337,6 +1338,20 @@ export const useAppStore = create<Store>()(
       get().splitPaneAt(active.id, 'right', view.id);
     }
     toast.success('Forked into a new pane');
+  },
+
+  handoffSessionToProvider: async (sessionId, targetProvider) => {
+    const result = await window.electron.sessionHandoff({ sessionId, targetProvider });
+    if (!result?.ok || !result.session) {
+      if (result?.message) toast.error(result.message);
+      return;
+    }
+    const view = freshSessionViewFromInfo(result.session);
+    set((state) => ({ sessions: { ...state.sessions, [view.id]: view } }));
+    // Handoff continues the same work — take over the focused pane.
+    const active = tree.getActiveLeaf(get().workspaceLayout);
+    get().placeSessionInPane(active.id, view.id);
+    toast.success('Handed off to a new session — context carries over on your next message.');
   },
 
 

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -231,6 +231,7 @@ export interface SessionView {
   source?: import('../shared/types').SessionSource;
   readOnly?: boolean;
   isDraft?: boolean;
+  handoffSourceProvider?: AgentProvider | null;
   latestClaudeModelUsage?: import('../shared/types').LatestClaudeModelUsage;
   messages: import('../shared/types').StreamMessage[];
   hydrated: boolean;
@@ -372,6 +373,7 @@ export interface AppActions {
   ) => void;
   // Fork a session's conversation and open the fork in a new pane.
   forkSessionToPane: (sessionId: string) => Promise<void>;
+  handoffSessionToProvider: (sessionId: string, targetProvider: AgentProvider) => Promise<void>;
   setDraftStartMode: (sessionId: string, mode: 'local' | 'worktree') => void;
   setShowNewSession: (show: boolean) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;


### PR DESCRIPTION
## Summary
- Sessions are now locked to one agent once a conversation exists — picking a different agent in the composer opens a **handoff confirm dialog** instead of silently switching (previously the new provider started completely cold with no context)
- Confirming creates a new session for the target provider (same project/cwd/worktree config), copies the transcript, and injects it into the first prompt as `<handoff_context>` — recent 6 turns nearly verbatim, earlier turns as one-line bullets, under a 24K char budget (ported from synara's thread handoff)
- The handoff session takes over the focused pane and shows a "Handoff from X" badge above the composer
- One-shot semantics: the pending flag clears after the first prompt, and the Claude history-replay bootstrap is skipped during injection so context never doubles up

## Test plan
- `node scripts/verify-session-handoff.mjs` — static wiring assertions pass
- `ELECTRON_RUN_AS_NODE=1 npx electron scripts/verify-session-handoff.mjs` — adds a functional sqlite pass (create → handoff → transcript copied, pending flag set/cleared, no resume-id inheritance); all pass
- `npm run transpile:electron`, `vite build`, `tsc` — no new errors
- Manual: chat with one agent, pick another in the composer → dialog → confirm → new session with history + badge → first message carries context

🤖 Generated with [Claude Code](https://claude.com/claude-code)