### PR TITLE
Race the setModel round-trip so a cancelled prompt can't wedge the enqueue chain

### DIFF
--- a/scripts/tests/claude-prompt-cancellation.test.ts
+++ b/scripts/tests/claude-prompt-cancellation.test.ts
@@ -64,121 +64,164 @@ void (async () => {
     assert.equal(pc.cancelPending(), 0, 'everything settled; a fresh stop cancels nothing');
   }
 
-  // Cancellation lands during the model round-trip — which, since the
-  // zero-turn stop path leaves the warm runner with NO fallback armed, must
-  // release the chain even if the control request NEVER resolves (a wedged
-  // CLI): the follow-up send queued behind it would otherwise hang with no
-  // recovery. Mirrors runner.ts: the switch is raced, a cancelled link
-  // bails, and the late completion still records the model bookkeeping —
-  // unless a newer link claimed the model since (epoch guard).
+  // ── Model-switch state machine (mirrors runner.ts) ─────────────────────────
+  // The CLI's model is not a settled scalar once switches can be abandoned:
+  // bookkeeping is tri-state — 'confirmed' (scalar matches the CLI, equal
+  // models may skip), 'pending' (a switch is in flight, possibly abandoned;
+  // links must issue their own switch), 'unknown' (the newest switch
+  // rejected; an explicit switch is required). Only the outcome of the most
+  // recently issued switch may transition the state.
+  type ModelState = 'confirmed' | 'pending' | 'unknown';
+  const makeModelHarness = (pc: ReturnType<typeof createPromptCancellation>) => {
+    let chain: Promise<void> = Promise.resolve();
+    const harness = {
+      currentModel: 'model-a' as string | undefined,
+      modelState: 'confirmed' as ModelState,
+      switchesIssued: [] as string[],
+      ran: [] as string[],
+      switchSeq: 0,
+      issueSwitch(target: string | undefined, work: Promise<void>): Promise<void> {
+        const mySeq = ++harness.switchSeq;
+        harness.modelState = 'pending';
+        harness.switchesIssued.push(target ?? '(default)');
+        work.then(
+          () => {
+            if (mySeq === harness.switchSeq) {
+              harness.currentModel = target;
+              harness.modelState = 'confirmed';
+            }
+          },
+          () => {
+            if (mySeq === harness.switchSeq) {
+              harness.modelState = 'unknown';
+            }
+          }
+        );
+        return work;
+      },
+      enqueue(target: string, work: Promise<void>, label: string) {
+        const seq = pc.issueSeq();
+        chain = chain
+          .then(async () => {
+            if (pc.isCancelled(seq)) return;
+            if (target !== harness.currentModel || harness.modelState !== 'confirmed') {
+              const modelSwitch = harness.issueSwitch(target, work);
+              const switched = await pc.race(modelSwitch.then(() => true as const));
+              if (switched === null) return;
+            }
+            if (pc.isCancelled(seq)) return;
+            harness.ran.push(label);
+          })
+          .catch(() => {
+            // a live link's switch rejection surfaces here (runner: onError)
+          })
+          .finally(() => pc.settle(seq));
+      },
+      settled(): Promise<string> {
+        return Promise.race([
+          chain.then(() => 'done'),
+          new Promise<string>((resolve) => setTimeout(resolve, 2_000, 'timeout')),
+        ]);
+      },
+    };
+    return harness;
+  };
+
+  // Wedged cancelled switch: the chain must release even if the control
+  // request NEVER resolves (after a zero-turn stop nothing else would
+  // reclaim it), and — P1 regression — a follow-up requesting the SAME
+  // display model must NOT trust the stale scalar: it issues its own switch,
+  // whose outcome (last issued wins on the serial stream) is the CLI's
+  // final state; the abandoned switch's late success is then ignored.
   {
     const pc = createPromptCancellation();
-    let chain: Promise<void> = Promise.resolve();
-    let buildStarted = false;
-    const ran: string[] = [];
-    let currentModel = 'model-a';
-    let modelSwitchEpoch = 0;
-    let releaseModelSwitch: () => void = () => {};
+    const h = makeModelHarness(pc);
+    let releaseOldSwitch: () => void = () => {};
     const wedgedSwitch = new Promise<void>((resolve) => {
-      releaseModelSwitch = resolve;
+      releaseOldSwitch = resolve;
     });
 
-    const enqueueWithSwitch = (targetModel: string, switchWork: Promise<void>, label: string) => {
-      const seq = pc.issueSeq();
-      chain = chain
-        .then(async () => {
-          if (pc.isCancelled(seq)) return;
-          if (targetModel !== currentModel) {
-            const switchEpoch = ++modelSwitchEpoch;
-            const switched = await pc.race(switchWork.then(() => true as const));
-            if (switched === null) {
-              void switchWork.then(
-                () => {
-                  if (modelSwitchEpoch === switchEpoch) {
-                    currentModel = targetModel;
-                  }
-                },
-                () => {}
-              );
-              return;
-            }
-            currentModel = targetModel;
-          }
-          if (pc.isCancelled(seq)) return;
-          buildStarted = label === 'A' ? true : buildStarted;
-          ran.push(label);
-        })
-        .finally(() => pc.settle(seq));
-    };
-
-    enqueueWithSwitch('model-b', wedgedSwitch, 'A');
-    await tick(); // link A is parked on the wedged setModel round-trip
+    h.enqueue('model-b', wedgedSwitch, 'B-prompt'); // A→B switch, then stop
+    await tick();
     assert.equal(pc.cancelPending(), 1, 'the mid-setModel prompt counts as pending');
 
-    // The user's immediate resend (no model change) must run even though the
-    // cancelled switch NEVER resolves.
-    enqueueWithSwitch('model-a', Promise.resolve(), 'B');
-    const outcome = await Promise.race([
-      chain.then(() => 'done'),
-      new Promise<string>((resolve) => setTimeout(resolve, 2_000, 'timeout')),
-    ]);
-    assert.equal(outcome, 'done', 'a wedged cancelled setModel must not block the chain');
-    assert.equal(buildStarted, false, 'the cancelled prompt never starts its prep');
-    assert.deepEqual(ran, ['B'], 'the resend ran; the cancelled prompt did not');
+    h.enqueue('model-a', Promise.resolve(), 'A-resend'); // same display model!
+    assert.equal(await h.settled(), 'done', 'a wedged cancelled switch must not block the chain');
+    assert.deepEqual(h.ran, ['A-resend'], 'the resend ran; the cancelled prompt did not');
+    assert.deepEqual(
+      h.switchesIssued,
+      ['model-b', 'model-a'],
+      'the same-model resend must issue its own switch — the pending A→B switch means the scalar lies'
+    );
+    assert.equal(h.currentModel, 'model-a', 'the resend confirmed its own model');
+    assert.equal(h.modelState, 'confirmed');
 
-    // If the abandoned switch DOES land later, its bookkeeping is recorded
-    // (the CLI really changed models) — the resend above claimed no epoch.
-    releaseModelSwitch();
+    releaseOldSwitch(); // the abandoned A→B switch lands after the newer one
     await tick();
-    assert.equal(currentModel, 'model-b', 'a late switch completion records the model');
+    assert.equal(h.currentModel, 'model-a', 'a superseded late success must not clobber the state');
   }
 
-  // The epoch guard: when a NEWER link claims the model after the cancelled
-  // one, the late completion must NOT clobber the newer bookkeeping.
+  // Cancelled switch with NO follow-up: the late completion still records
+  // the model — the CLI really changed, and the next send must compare
+  // against reality.
   {
     const pc = createPromptCancellation();
-    let chain: Promise<void> = Promise.resolve();
-    let currentModel = 'model-a';
-    let modelSwitchEpoch = 0;
+    const h = makeModelHarness(pc);
+    let releaseSwitch: () => void = () => {};
+    const slowSwitch = new Promise<void>((resolve) => {
+      releaseSwitch = resolve;
+    });
+    h.enqueue('model-b', slowSwitch, 'B-prompt');
+    await tick();
+    pc.cancelPending();
+    assert.equal(await h.settled(), 'done');
+    assert.equal(h.modelState, 'pending', 'the abandoned switch is still unsettled');
+    releaseSwitch();
+    await tick();
+    assert.equal(h.currentModel, 'model-b', 'the newest switch, however late, confirms the model');
+    assert.equal(h.modelState, 'confirmed');
+  }
+
+  // P2 regression: a NEWER switch that REJECTS must not hide the older
+  // cancelled switch's completion behind stale bookkeeping. The rejection
+  // moves the state to 'unknown', the old success is superseded (ignored),
+  // and the next prompt — even for the ORIGINAL model — must issue an
+  // explicit switch instead of trusting the scalar.
+  {
+    const pc = createPromptCancellation();
+    const h = makeModelHarness(pc);
     let releaseOldSwitch: () => void = () => {};
     const oldSwitch = new Promise<void>((resolve) => {
       releaseOldSwitch = resolve;
     });
+    let rejectNewSwitch: (error: Error) => void = () => {};
+    const doomedSwitch = new Promise<void>((_resolve, reject) => {
+      rejectNewSwitch = reject;
+    });
 
-    const enqueueWithSwitch = (targetModel: string, switchWork: Promise<void>) => {
-      const seq = pc.issueSeq();
-      chain = chain
-        .then(async () => {
-          if (pc.isCancelled(seq)) return;
-          if (targetModel !== currentModel) {
-            const switchEpoch = ++modelSwitchEpoch;
-            const switched = await pc.race(switchWork.then(() => true as const));
-            if (switched === null) {
-              void switchWork.then(
-                () => {
-                  if (modelSwitchEpoch === switchEpoch) {
-                    currentModel = targetModel;
-                  }
-                },
-                () => {}
-              );
-              return;
-            }
-            currentModel = targetModel;
-          }
-        })
-        .finally(() => pc.settle(seq));
-    };
-
-    enqueueWithSwitch('model-b', oldSwitch); // stop lands mid round-trip
+    h.enqueue('model-b', oldSwitch, 'B-prompt'); // A→B, stopped mid round-trip
     await tick();
     pc.cancelPending();
-    enqueueWithSwitch('model-c', Promise.resolve()); // resend claims a newer switch
+    h.enqueue('model-c', doomedSwitch, 'C-prompt'); // live follow-up, will fail
     await tick();
-    assert.equal(currentModel, 'model-c', 'the resend recorded its own switch');
-    releaseOldSwitch(); // the abandoned switch lands after the newer claim
+    rejectNewSwitch(new Error('setModel failed'));
+    assert.equal(await h.settled(), 'done');
+    assert.equal(h.modelState, 'unknown', 'the newest switch rejected — the CLI model is uncertain');
+
+    releaseOldSwitch(); // the old A→B switch lands late
     await tick();
-    assert.equal(currentModel, 'model-c', 'a stale late completion must not clobber it');
+    assert.equal(h.modelState, 'unknown', 'a superseded success must not fake a confirmation');
+
+    h.enqueue('model-a', Promise.resolve(), 'A-prompt'); // original model!
+    assert.equal(await h.settled(), 'done');
+    assert.deepEqual(
+      h.switchesIssued,
+      ['model-b', 'model-c', 'model-a'],
+      'with the model unknown, even the original-model prompt must switch explicitly'
+    );
+    assert.equal(h.currentModel, 'model-a');
+    assert.equal(h.modelState, 'confirmed');
+    assert.deepEqual(h.ran, ['A-prompt'], 'only the healthy prompt ran');
   }
 
   // A cancelled setModel that eventually REJECTS is abandoned work: it must

--- a/scripts/tests/claude-prompt-cancellation.test.ts
+++ b/scripts/tests/claude-prompt-cancellation.test.ts
@@ -64,41 +64,141 @@ void (async () => {
     assert.equal(pc.cancelPending(), 0, 'everything settled; a fresh stop cancels nothing');
   }
 
-  // Cancellation lands during the (deliberately unraced) model round-trip:
-  // cancelPending() has already minted a FRESH signal, so a build started
-  // after setModel resolves could never be released by the race — the link
-  // must bail via the watermark BEFORE starting the attachment prep, or the
-  // abandoned work blocks the serial chain and delays the resend.
+  // Cancellation lands during the model round-trip — which, since the
+  // zero-turn stop path leaves the warm runner with NO fallback armed, must
+  // release the chain even if the control request NEVER resolves (a wedged
+  // CLI): the follow-up send queued behind it would otherwise hang with no
+  // recovery. Mirrors runner.ts: the switch is raced, a cancelled link
+  // bails, and the late completion still records the model bookkeeping —
+  // unless a newer link claimed the model since (epoch guard).
   {
     const pc = createPromptCancellation();
     let chain: Promise<void> = Promise.resolve();
     let buildStarted = false;
+    const ran: string[] = [];
+    let currentModel = 'model-a';
+    let modelSwitchEpoch = 0;
     let releaseModelSwitch: () => void = () => {};
-    const modelSwitch = new Promise<void>((resolve) => {
+    const wedgedSwitch = new Promise<void>((resolve) => {
       releaseModelSwitch = resolve;
     });
 
-    const seq = pc.issueSeq();
-    chain = chain
-      .then(async () => {
-        if (pc.isCancelled(seq)) return;
-        await modelSwitch; // setModel — not raced by design
-        if (pc.isCancelled(seq)) return; // ← the re-check under test
-        buildStarted = true;
-        await pc.race(new Promise<string>(() => {})); // never-finishing prep
-      })
-      .finally(() => pc.settle(seq));
+    const enqueueWithSwitch = (targetModel: string, switchWork: Promise<void>, label: string) => {
+      const seq = pc.issueSeq();
+      chain = chain
+        .then(async () => {
+          if (pc.isCancelled(seq)) return;
+          if (targetModel !== currentModel) {
+            const switchEpoch = ++modelSwitchEpoch;
+            const switched = await pc.race(switchWork.then(() => true as const));
+            if (switched === null) {
+              void switchWork.then(
+                () => {
+                  if (modelSwitchEpoch === switchEpoch) {
+                    currentModel = targetModel;
+                  }
+                },
+                () => {}
+              );
+              return;
+            }
+            currentModel = targetModel;
+          }
+          if (pc.isCancelled(seq)) return;
+          buildStarted = label === 'A' ? true : buildStarted;
+          ran.push(label);
+        })
+        .finally(() => pc.settle(seq));
+    };
 
-    await tick(); // link is parked on the model round-trip
+    enqueueWithSwitch('model-b', wedgedSwitch, 'A');
+    await tick(); // link A is parked on the wedged setModel round-trip
     assert.equal(pc.cancelPending(), 1, 'the mid-setModel prompt counts as pending');
-    releaseModelSwitch();
 
+    // The user's immediate resend (no model change) must run even though the
+    // cancelled switch NEVER resolves.
+    enqueueWithSwitch('model-a', Promise.resolve(), 'B');
     const outcome = await Promise.race([
       chain.then(() => 'done'),
       new Promise<string>((resolve) => setTimeout(resolve, 2_000, 'timeout')),
     ]);
-    assert.equal(outcome, 'done', 'link bails after the model step; the chain never blocks');
-    assert.equal(buildStarted, false, 'a cancelled prompt must not start attachment prep');
+    assert.equal(outcome, 'done', 'a wedged cancelled setModel must not block the chain');
+    assert.equal(buildStarted, false, 'the cancelled prompt never starts its prep');
+    assert.deepEqual(ran, ['B'], 'the resend ran; the cancelled prompt did not');
+
+    // If the abandoned switch DOES land later, its bookkeeping is recorded
+    // (the CLI really changed models) — the resend above claimed no epoch.
+    releaseModelSwitch();
+    await tick();
+    assert.equal(currentModel, 'model-b', 'a late switch completion records the model');
+  }
+
+  // The epoch guard: when a NEWER link claims the model after the cancelled
+  // one, the late completion must NOT clobber the newer bookkeeping.
+  {
+    const pc = createPromptCancellation();
+    let chain: Promise<void> = Promise.resolve();
+    let currentModel = 'model-a';
+    let modelSwitchEpoch = 0;
+    let releaseOldSwitch: () => void = () => {};
+    const oldSwitch = new Promise<void>((resolve) => {
+      releaseOldSwitch = resolve;
+    });
+
+    const enqueueWithSwitch = (targetModel: string, switchWork: Promise<void>) => {
+      const seq = pc.issueSeq();
+      chain = chain
+        .then(async () => {
+          if (pc.isCancelled(seq)) return;
+          if (targetModel !== currentModel) {
+            const switchEpoch = ++modelSwitchEpoch;
+            const switched = await pc.race(switchWork.then(() => true as const));
+            if (switched === null) {
+              void switchWork.then(
+                () => {
+                  if (modelSwitchEpoch === switchEpoch) {
+                    currentModel = targetModel;
+                  }
+                },
+                () => {}
+              );
+              return;
+            }
+            currentModel = targetModel;
+          }
+        })
+        .finally(() => pc.settle(seq));
+    };
+
+    enqueueWithSwitch('model-b', oldSwitch); // stop lands mid round-trip
+    await tick();
+    pc.cancelPending();
+    enqueueWithSwitch('model-c', Promise.resolve()); // resend claims a newer switch
+    await tick();
+    assert.equal(currentModel, 'model-c', 'the resend recorded its own switch');
+    releaseOldSwitch(); // the abandoned switch lands after the newer claim
+    await tick();
+    assert.equal(currentModel, 'model-c', 'a stale late completion must not clobber it');
+  }
+
+  // A cancelled setModel that eventually REJECTS is abandoned work: it must
+  // neither surface as a runner error nor crash the process.
+  {
+    const pc = createPromptCancellation();
+    let rejectSwitch: (error: Error) => void = () => {};
+    const doomedSwitch = new Promise<void>((_resolve, reject) => {
+      rejectSwitch = reject;
+    });
+    pc.issueSeq();
+    const raced = pc.race(doomedSwitch.then(() => true as const));
+    pc.cancelPending();
+    assert.equal(await raced, null, 'cancellation wins over the wedged switch');
+    void doomedSwitch.then(
+      () => {},
+      () => {}
+    );
+    rejectSwitch(new Error('control request failed after cancel'));
+    await tick();
   }
 
   // Cancellation lands BEFORE the link starts: the entry watermark check

--- a/scripts/verify-claude-interrupt-stop.mjs
+++ b/scripts/verify-claude-interrupt-stop.mjs
@@ -177,10 +177,25 @@ assert.match(
   /await promptCancellation\.race\(\s*buildUserMessage\(/,
   'the long prepare step must race cancellation so the chain settles immediately'
 );
+// The model round-trip is raced too: after a zero-turn stop the warm runner
+// has NO fallback armed, so a cancelled enqueue wedged on setModel would
+// otherwise block every follow-up send with no recovery. The switch's late
+// completion still records the model bookkeeping (epoch-guarded so a newer
+// link's switch wins) and its late rejection is swallowed as abandoned work.
 assert.match(
   runnerSource,
-  /await activeQuery\.setModel\(nextRuntimeModel\);[\s\S]{0,900}?promptCancellation\.isCancelled\(seq\)[\s\S]{0,300}?await promptCancellation\.race\(\s*buildUserMessage\(/,
-  'a stop during the model round-trip must bail before starting attachment prep'
+  /const modelSwitch = activeQuery\.setModel\(nextRuntimeModel\);\s*const switched = await promptCancellation\.race\(/,
+  'the setModel round-trip must race cancellation so a wedged switch cannot block the chain'
+);
+assert.match(
+  runnerSource,
+  /if \(switched === null\) \{[\s\S]{0,700}?void modelSwitch\.then\([\s\S]{0,400}?modelSwitchEpoch === switchEpoch/,
+  'a cancelled switch must record its late completion under the epoch guard'
+);
+assert.match(
+  runnerSource,
+  /promptCancellation\.isCancelled\(seq\)[\s\S]{0,400}?await promptCancellation\.race\(\s*buildUserMessage\(/,
+  'the link must re-check cancellation before starting attachment prep'
 );
 assert.match(
   runnerSource,

--- a/scripts/verify-claude-interrupt-stop.mjs
+++ b/scripts/verify-claude-interrupt-stop.mjs
@@ -179,18 +179,36 @@ assert.match(
 );
 // The model round-trip is raced too: after a zero-turn stop the warm runner
 // has NO fallback armed, so a cancelled enqueue wedged on setModel would
-// otherwise block every follow-up send with no recovery. The switch's late
-// completion still records the model bookkeeping (epoch-guarded so a newer
-// link's switch wins) and its late rejection is swallowed as abandoned work.
+// otherwise block every follow-up send with no recovery. Model bookkeeping
+// is tri-state (confirmed/pending/unknown): equal models may only skip a
+// switch while CONFIRMED, a pending/unknown state forces the link to issue
+// its own switch (last issued wins on the serial stream), and only the most
+// recently issued switch's outcome may transition the state — so a rejected
+// newer switch cannot be shadowed by an older switch's late success.
 assert.match(
   runnerSource,
-  /const modelSwitch = activeQuery\.setModel\(nextRuntimeModel\);\s*const switched = await promptCancellation\.race\(/,
+  /const modelSwitch = issueModelSwitch\(normalizedModel, nextRuntimeModel\);\s*const switched = await promptCancellation\.race\(/,
   'the setModel round-trip must race cancellation so a wedged switch cannot block the chain'
 );
 assert.match(
   runnerSource,
-  /if \(switched === null\) \{[\s\S]{0,700}?void modelSwitch\.then\([\s\S]{0,400}?modelSwitchEpoch === switchEpoch/,
-  'a cancelled switch must record its late completion under the epoch guard'
+  /normalizedModel !== currentModel \|\| modelState !== 'confirmed'/,
+  'equal display models may only skip switching while the bookkeeping is confirmed'
+);
+assert.match(
+  runnerSource,
+  /nextRuntimeModel !== currentRuntimeModel \|\| modelState !== 'confirmed'/,
+  'a pending or unknown model state must force the link to issue its own switch'
+);
+assert.match(
+  runnerSource,
+  /if \(switchSeq === modelSwitchSeq\) \{\s*currentModel = targetDisplayModel;[\s\S]{0,200}?modelState = 'confirmed';/,
+  'only the newest switch may confirm the model bookkeeping'
+);
+assert.match(
+  runnerSource,
+  /if \(switchSeq === modelSwitchSeq\) \{\s*modelState = 'unknown';/,
+  'a rejected newest switch must mark the CLI model unknown'
 );
 assert.match(
   runnerSource,

--- a/src/electron/libs/runner.ts
+++ b/src/electron/libs/runner.ts
@@ -535,12 +535,53 @@ export function runClaude(options: RunnerOptions): RunnerHandle {
   // against cancellation so the serial chain settles immediately — a
   // follow-up send must never wait on the very work the user just stopped,
   // and after a zero-turn stop the warm runner has no fallback armed to
-  // reclaim a chain wedged on an abandoned control request. The model
-  // switch's effect lands on the CLI either way, so its bookkeeping is
-  // recorded even when the prompt that issued it was cancelled (epoch-
-  // guarded so a newer link's switch always wins).
+  // reclaim a chain wedged on an abandoned control request.
   const promptCancellation = createPromptCancellation();
-  let modelSwitchEpoch = 0;
+
+  // The CLI's model is NOT a settled scalar once switches can be abandoned
+  // mid round-trip: currentModel/currentRuntimeModel describe the CLI only
+  // while modelState is 'confirmed'.
+  //   'confirmed' — bookkeeping matches the CLI; equal models may skip.
+  //   'pending'   — a switch is in flight (possibly cancelled-and-abandoned);
+  //                 its outcome is not known yet, so NO link may trust the
+  //                 scalar comparison: it must issue its own switch. Requests
+  //                 are served in order on the single stream, so the switch
+  //                 issued last always describes the CLI's final state.
+  //   'unknown'   — the most recently issued switch REJECTED; the CLI's
+  //                 model is uncertain until an explicit switch confirms it.
+  // Only the outcome of the most recently issued switch may transition the
+  // state: an older switch that settles late — success or failure — is
+  // superseded and must not clobber newer bookkeeping.
+  let modelState: 'confirmed' | 'pending' | 'unknown' = 'confirmed';
+  let modelSwitchSeq = 0;
+
+  const issueModelSwitch = (
+    targetDisplayModel: string | undefined,
+    targetRuntimeModel: string | undefined
+  ): Promise<void> => {
+    const switchSeq = ++modelSwitchSeq;
+    modelState = 'pending';
+    const modelSwitch = activeQuery!.setModel(targetRuntimeModel);
+    // Attached at issue time so the outcome is recorded no matter which
+    // prompt abandoned it, and so an abandoned rejection can never become an
+    // unhandled rejection (the live link still observes it via its own
+    // raced await on the same promise).
+    modelSwitch.then(
+      () => {
+        if (switchSeq === modelSwitchSeq) {
+          currentModel = targetDisplayModel;
+          currentRuntimeModel = targetRuntimeModel;
+          modelState = 'confirmed';
+        }
+      },
+      () => {
+        if (switchSeq === modelSwitchSeq) {
+          modelState = 'unknown';
+        }
+      }
+    );
+    return modelSwitch;
+  };
 
   const enqueuePrompt = (text: string, promptAttachments?: Attachment[], requestedModel?: string) => {
     const trimmed = text.trim();
@@ -560,47 +601,40 @@ export function runClaude(options: RunnerOptions): RunnerHandle {
         if (abortController.signal.aborted || promptCancellation.isCancelled(seq)) {
           return;
         }
-        if (activeQuery && normalizedModel !== currentModel) {
+        // Equal display models may only short-circuit while the bookkeeping
+        // is CONFIRMED: with a switch pending (possibly abandoned by a stop)
+        // or after a rejected one, the scalar comparison lies about the CLI.
+        if (activeQuery && (normalizedModel !== currentModel || modelState !== 'confirmed')) {
           const nextRuntimeModel = compatibleProviderMatched
             ? currentRuntimeModel
             : toClaudeCodeRuntimeModel(normalizedModel, betas);
           // Only touch the live query when the RESOLVED runtime model actually
           // changes — a display-model spelling (e.g. the reconciled name the
-          // init handler stores) must not trigger a spurious switch on reuse.
-          if (nextRuntimeModel !== currentRuntimeModel) {
+          // init handler stores) must not trigger a spurious switch on reuse —
+          // or when the CLI's model is not confirmed, in which case this link
+          // must issue its own switch: it is the last one issued, so its
+          // outcome describes the CLI's final state no matter what an
+          // abandoned earlier switch does.
+          if (nextRuntimeModel !== currentRuntimeModel || modelState !== 'confirmed') {
             // Raced against cancellation: a stop that cancels this prompt
             // must never leave the serial chain parked behind a wedged
             // control request — after a zero-turn stop the runner stays warm
             // with no fallback armed, so nothing else would ever release a
-            // follow-up send queued behind it. The switch itself still lands
-            // on the CLI either way, so the bookkeeping must record it even
-            // when this prompt was cancelled mid round-trip: a follow-up
-            // comparing against stale state would skip a needed switch back.
-            const switchEpoch = ++modelSwitchEpoch;
-            const modelSwitch = activeQuery.setModel(nextRuntimeModel);
+            // follow-up send queued behind it. The state machine attached at
+            // issue time records the outcome (confirmed / unknown) whenever
+            // the round-trip settles, cancelled or not.
+            const modelSwitch = issueModelSwitch(normalizedModel, nextRuntimeModel);
             const switched = await promptCancellation.race(
               modelSwitch.then(() => true as const)
             );
             if (switched === null) {
-              // Cancelled mid round-trip: record the switch when (if) it
-              // lands — unless a newer link has claimed the model since, in
-              // which case that link's switch is the CLI's final state and
-              // its bookkeeping must stand. A late rejection is abandoned
-              // work and must not surface as this session's runner error.
-              void modelSwitch.then(
-                () => {
-                  if (modelSwitchEpoch === switchEpoch) {
-                    currentModel = normalizedModel;
-                    currentRuntimeModel = nextRuntimeModel;
-                  }
-                },
-                () => {}
-              );
               return;
             }
+          } else {
+            // Display-spelling refresh only; the CLI model is unchanged.
+            currentModel = normalizedModel;
+            currentRuntimeModel = nextRuntimeModel;
           }
-          currentModel = normalizedModel;
-          currentRuntimeModel = nextRuntimeModel;
         }
         // Cancellation can land in the same tick the model round-trip
         // resolves (the work may win the race even though the stop already

--- a/src/electron/libs/runner.ts
+++ b/src/electron/libs/runner.ts
@@ -531,13 +531,16 @@ export function runClaude(options: RunnerOptions): RunnerHandle {
   // a send is still ahead of the input queue. cancelPendingPrompts() marks
   // every enqueue issued so far as cancelled; the enqueue re-checks the mark
   // after each await so a cancelled prompt is never pushed to the CLI, and
-  // the long prepare step races against cancellation so the serial chain
-  // settles immediately — a follow-up send must never wait on the very work
-  // the user just stopped. The model round-trip is deliberately NOT raced:
-  // it is a fast control request whose effect lands on the CLI either way,
-  // so bookkeeping must record it, and a wedged CLI blocks the resend
-  // regardless (the stop fallback reclaims that runner).
+  // every long step (attachment prep AND the setModel round-trip) races
+  // against cancellation so the serial chain settles immediately — a
+  // follow-up send must never wait on the very work the user just stopped,
+  // and after a zero-turn stop the warm runner has no fallback armed to
+  // reclaim a chain wedged on an abandoned control request. The model
+  // switch's effect lands on the CLI either way, so its bookkeeping is
+  // recorded even when the prompt that issued it was cancelled (epoch-
+  // guarded so a newer link's switch always wins).
   const promptCancellation = createPromptCancellation();
+  let modelSwitchEpoch = 0;
 
   const enqueuePrompt = (text: string, promptAttachments?: Attachment[], requestedModel?: string) => {
     const trimmed = text.trim();
@@ -565,19 +568,46 @@ export function runClaude(options: RunnerOptions): RunnerHandle {
           // changes — a display-model spelling (e.g. the reconciled name the
           // init handler stores) must not trigger a spurious switch on reuse.
           if (nextRuntimeModel !== currentRuntimeModel) {
-            await activeQuery.setModel(nextRuntimeModel);
+            // Raced against cancellation: a stop that cancels this prompt
+            // must never leave the serial chain parked behind a wedged
+            // control request — after a zero-turn stop the runner stays warm
+            // with no fallback armed, so nothing else would ever release a
+            // follow-up send queued behind it. The switch itself still lands
+            // on the CLI either way, so the bookkeeping must record it even
+            // when this prompt was cancelled mid round-trip: a follow-up
+            // comparing against stale state would skip a needed switch back.
+            const switchEpoch = ++modelSwitchEpoch;
+            const modelSwitch = activeQuery.setModel(nextRuntimeModel);
+            const switched = await promptCancellation.race(
+              modelSwitch.then(() => true as const)
+            );
+            if (switched === null) {
+              // Cancelled mid round-trip: record the switch when (if) it
+              // lands — unless a newer link has claimed the model since, in
+              // which case that link's switch is the CLI's final state and
+              // its bookkeeping must stand. A late rejection is abandoned
+              // work and must not surface as this session's runner error.
+              void modelSwitch.then(
+                () => {
+                  if (modelSwitchEpoch === switchEpoch) {
+                    currentModel = normalizedModel;
+                    currentRuntimeModel = nextRuntimeModel;
+                  }
+                },
+                () => {}
+              );
+              return;
+            }
           }
-          // Recorded even if this prompt was cancelled mid-flight: the CLI's
-          // model DID change, and a follow-up send comparing against stale
-          // bookkeeping would skip a needed switch back.
           currentModel = normalizedModel;
           currentRuntimeModel = nextRuntimeModel;
         }
-        // A stop can land during the (deliberately unraced) model round-trip
-        // above. Cancellation minted a FRESH signal, so a build started now
-        // could no longer be released by the race — bail before starting the
-        // attachment prep at all, or the abandoned work would block the
-        // serial chain and delay the user's immediate resend.
+        // Cancellation can land in the same tick the model round-trip
+        // resolves (the work may win the race even though the stop already
+        // marked this prompt). Re-check before starting the attachment prep:
+        // cancelPendingPrompts minted a FRESH signal, so a build started now
+        // could no longer be released by the race — the abandoned work would
+        // block the serial chain and delay the user's immediate resend.
         if (abortController.signal.aborted || promptCancellation.isCancelled(seq)) {
           return;
         }


### PR DESCRIPTION
Follow-up to #39 (soft-stop). A late Codex review of that PR's final head raised one valid P2 that merged into master: ["Don't treat cancelled model switches as drained"](https://github.com/DylanDDeng/bubble-cowork/pull/39#discussion_r3526978066).

## Problem

When stop cancels the only counted prompt, the zero-turn stand-down path deliberately leaves the runner warm with **no interrupt and no fallback timer** — its premise being that cancelled work never blocks a resend. But the cancelled enqueue could still be parked in the **unraced** `await activeQuery.setModel(...)` (the cancellation re-check ran only after that await). If the CLI wedges on that control request:

- a follow-up send chains behind the parked link indefinitely, with nothing armed to reclaim it (pre-soft-stop, the hard abort killed the process), or
- a late `setModel` rejection propagates through the chain's `.catch` → `onError` and can surface as the follow-up's runner error after `inFlightTurns` re-increments.

## Change

The model round-trip now goes through `promptCancellation.race()` exactly like the attachment prep, so a cancelled link releases the serial chain within a microtask of the stop wherever it is parked — making the zero-turn stand-down's premise hold unconditionally.

The **bookkeeping-must-record invariant** from #39 is preserved: the switch's effect lands on the CLI either way, so a cancelled link still records `currentModel`/`currentRuntimeModel` when the round-trip eventually completes — now guarded by a model-switch **epoch** so a newer link's own switch (the CLI's actual final state) is never clobbered by the stale late completion. A late rejection is swallowed as abandoned work, matching the attachment-prep path, so it can never be misattributed to the live session.

## Verification

- `claude-prompt-cancellation.test.ts`: a wedged cancelled switch never blocks the resend and never starts its prep (2s watchdog); a late completion records the model; a stale completion after a newer claim does **not** clobber it; a late rejection neither surfaces nor crashes.
- `verify:claude-interrupt-stop` asserts the raced switch, the epoch-guarded late record, and the pre-build cancellation re-check.
- `transpile:electron` clean; `verify:claude-interrupt-stop` / `verify:claude-turn-latency` / `verify:subagent-workstream` / `verify:prompt-history` all pass; full `npm test` and `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)