### PR TITLE
Fix runner-reuse regression: alias-model sessions cold-respawned and errored on every follow-up

### DIFF
--- a/scripts/tests/claude-model-selection.test.ts
+++ b/scripts/tests/claude-model-selection.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { isSameClaudeModelSelection } from '../../src/electron/libs/claude-model-selection';
+
+// Regression: a session started on a family alias gets its stored model
+// overwritten at init with the CLI-resolved CONCRETE id; the composer keeps
+// sending the alias. Reading that as a model change made EVERY follow-up
+// message abort the warm runner (cold respawn + "Operation aborted" noise).
+assert.equal(
+  isSameClaudeModelSelection('opus', 'claude-opus-4-8'),
+  true,
+  'alias vs the concrete id it resolved to is the same selection'
+);
+assert.equal(
+  isSameClaudeModelSelection('claude-opus-4-8', 'opus'),
+  true,
+  'symmetric: stored alias vs requested concrete of the same family'
+);
+assert.equal(
+  isSameClaudeModelSelection('sonnet', 'claude-sonnet-4-9-20260112'),
+  true,
+  'any concrete version of the family matches its alias'
+);
+assert.equal(
+  isSameClaudeModelSelection('opus', 'claude-opus-4-8[1m]'),
+  true,
+  'the 1m-context variant belongs to the same family (betas carry the 1m change)'
+);
+
+// Identical strings and normalization equivalences.
+assert.equal(isSameClaudeModelSelection('opus', 'opus'), true);
+assert.equal(isSameClaudeModelSelection('Opus', 'opus'), true, 'aliases normalize case');
+assert.equal(
+  isSameClaudeModelSelection('claude-opus-4-8', 'claude-opus-4-8'),
+  true,
+  'identical concrete ids match'
+);
+
+// Real changes must still read as changes.
+assert.equal(isSameClaudeModelSelection('opus', 'sonnet'), false, 'different aliases differ');
+assert.equal(
+  isSameClaudeModelSelection('sonnet', 'claude-opus-4-8'),
+  false,
+  'alias vs a concrete id of a DIFFERENT family is a change'
+);
+assert.equal(
+  isSameClaudeModelSelection('claude-opus-4-8', 'claude-opus-4-9'),
+  false,
+  'two different concrete ids are a real change (explicit pins stay honored)'
+);
+assert.equal(
+  isSameClaudeModelSelection(undefined, 'opus'),
+  false,
+  'missing vs present is a change'
+);
+assert.equal(isSameClaudeModelSelection('opus', undefined), false);
+assert.equal(isSameClaudeModelSelection(undefined, undefined), true, 'both unset is unchanged');
+
+// Unknown model shapes never accidentally match an alias.
+assert.equal(
+  isSameClaudeModelSelection('opus', 'gpt-omega'),
+  false,
+  'non-Claude shapes are not family members'
+);
+assert.equal(
+  isSameClaudeModelSelection('opus', 'claude-opusx-1'),
+  false,
+  'family match requires a word boundary, not a prefix'
+);
+
+console.log('claude-model-selection.test: all assertions passed');

--- a/scripts/verify-claude-turn-latency.mjs
+++ b/scripts/verify-claude-turn-latency.mjs
@@ -139,6 +139,36 @@ assert.equal(
   'slash-command failure must doom the kept-alive runner'
 );
 
+// Reuse regression guards (family alias vs init-resolved concrete id made
+// every follow-up abort the warm runner and flip the session to error):
+// - the Claude model-change gate must be alias-aware;
+// - deliberate aborts must be swallowed whatever error shape the SDK throws
+//   (its transport raises a plain Error named 'Error' with message
+//   'Operation aborted', not an AbortError);
+// - a stale (replaced/retired) handle's late teardown error must never flip
+//   the live session to error — only the mapped handle may.
+assert.equal(
+  ipcSource.includes('!isSameClaudeModelSelection(nextModel, previousModel)'),
+  true,
+  'the continue model-change gate must compare alias-aware for Claude'
+);
+{
+  const runnerSourceForAbort = fs.readFileSync(
+    path.join(root, 'src', 'electron', 'libs', 'runner.ts'),
+    'utf8'
+  );
+  assert.match(
+    runnerSourceForAbort,
+    /abortController\.signal\.aborted \|\|\s*\(error instanceof Error &&\s*\(error\.name === 'AbortError' \|\| \/operation aborted\/i\.test\(error\.message\)\)\)/,
+    'the runner must swallow every deliberate-abort error shape'
+  );
+}
+assert.match(
+  ipcSource,
+  /if \(mappedEntry\?\.handle !== handle\) \{\s*return;\s*\}/,
+  'onError must silently drop errors from any stale (replaced) handle'
+);
+
 // Reuse must be cwd-guarded: a live runner is bound to its spawn cwd.
 assert.equal(
   ipcSource.includes('cwd: runnerSession.cwd || null'),
@@ -264,6 +294,7 @@ const compile = spawnSync(
     tmpDir,
     'scripts/tests/claude-runtime-cache.test.ts',
     'scripts/tests/claude-runner-pool.test.ts',
+    'scripts/tests/claude-model-selection.test.ts',
   ],
   { cwd: root, stdio: 'inherit' }
 );
@@ -272,7 +303,11 @@ if (compile.status !== 0) {
   process.exit(compile.status ?? 1);
 }
 
-for (const testFile of ['claude-runtime-cache.test.js', 'claude-runner-pool.test.js']) {
+for (const testFile of [
+  'claude-runtime-cache.test.js',
+  'claude-runner-pool.test.js',
+  'claude-model-selection.test.js',
+]) {
   const testPath = path.join(tmpDir, 'scripts', 'tests', testFile);
   const run = spawnSync(process.execPath, [testPath], { cwd: root, stdio: 'inherit' });
   if (run.status !== 0) {

--- a/src/electron/ipc-handlers.ts
+++ b/src/electron/ipc-handlers.ts
@@ -18,7 +18,7 @@ import {
 } from './libs/util';
 import { ensureProviderService, runAgentLoop } from './libs/agent-loop';
 import { readProjectTree } from './libs/project-tree';
-import { normalizeClaudeRequestedModel, reconcileClaudeDisplayModel } from './libs/claude-model-selection';
+import { isSameClaudeModelSelection, normalizeClaudeRequestedModel, reconcileClaudeDisplayModel } from './libs/claude-model-selection';
 import { loadClaudeSettings, getClaudeSettings, getClaudeModelConfigWithCatalog, getMcpServers, getGlobalMcpServers, getProjectMcpServers, saveMcpServers, saveProjectMcpServers, type McpServerConfig } from './libs/claude-settings';
 import { getCodexMcpServers, saveCodexMcpServers } from './libs/codex-mcp-settings';
 import {
@@ -7640,7 +7640,15 @@ async function handleSessionContinue(
   const previousModel = normalizeModel(session.model ?? undefined);
   const providerChanged = nextProvider !== previousProvider;
   const compatibleProviderChanged = nextCompatibleProviderId !== previousCompatibleProviderId;
-  const modelChanged = nextModel !== previousModel;
+  // Claude compares alias-aware: init records the concrete model id the CLI
+  // resolved a family alias to, while the composer keeps sending the alias —
+  // a raw string comparison read that as a model change on EVERY follow-up,
+  // aborting the warm runner (cold respawn + an "Operation aborted" error
+  // toast from the torn-down stream) each message.
+  const modelChanged =
+    nextProvider === 'claude'
+      ? !isSameClaudeModelSelection(nextModel, previousModel)
+      : nextModel !== previousModel;
   const betasChanged = JSON.stringify(nextBetas || []) !== JSON.stringify(previousBetas || []);
   const previousClaudeAccessMode = normalizeClaudeAccessMode(session.claude_access_mode);
   const nextClaudeAccessMode =
@@ -7752,6 +7760,12 @@ async function handleSessionContinue(
     normalizeOpenCodePermissionMode(
       runnerHandles.get(sessionId)?.opencodePermissionMode || previousOpenCodePermissionMode
     ) !== nextOpenCodePermissionMode;
+  // Every live runner is bound to the cwd it spawned with. If the session's
+  // workspace moved since (handoff, worktree move, external mutation), the
+  // handle must never be reused — for any provider — or the next turn would
+  // execute against the old checkout.
+  const runnerCwdChanged =
+    existingEntry !== undefined && (existingEntry.cwd ?? null) !== effectiveRunnerCwd(session);
   // 运行时状态检查已移动到会话状态广播之后，以便前端立即显示 spinning 效果
 
   if (isDev()) {
@@ -7761,13 +7775,19 @@ async function handleSessionContinue(
       previousProvider,
       nextProvider,
       nextModel,
+      previousModel,
       nextCompatibleProviderId,
       nextBetas,
       providerChanged,
       compatibleProviderChanged,
+      modelChanged,
       betasChanged,
       accessModeChanged,
+      executionModeChanged,
       claudeReasoningEffortChanged,
+      runnerCwdChanged,
+      entryDoomed: existingEntry?.doomed === true,
+      entryAutoApprove: existingEntry?.autoApprove === true,
       codexExecutionModeChanged,
       codexPermissionModeChanged,
       codexReasoningEffortChanged,
@@ -7916,13 +7936,6 @@ async function handleSessionContinue(
       return false;
     }
   }
-
-  // Every live runner is bound to the cwd it spawned with. If the session's
-  // workspace moved since (handoff, worktree move, external mutation), the
-  // handle must never be reused — for any provider — or the next turn would
-  // execute against the old checkout.
-  const runnerCwdChanged =
-    existingEntry !== undefined && (existingEntry.cwd ?? null) !== effectiveRunnerCwd(session);
 
   if (existingEntry && !providerChanged && existingEntry.provider === nextProvider) {
     if (
@@ -8651,11 +8664,14 @@ function startRunner(
         return;
       }
 
-      // A stale handle (this runner was already retired or replaced) that the
-      // user had stopped: its late teardown noise must not mark the session —
-      // now owned by a different runner, or by none — as failed. There is
-      // nothing to clean up here; the replacement entry is not ours to touch.
-      if (mappedEntry?.handle !== handle && userStoppedRunnerHandles.has(handle)) {
+      // A stale handle — this runner was already retired or replaced for ANY
+      // reason (user stop, model/config change, provider switch, reaper) —
+      // tearing down late is never the live session's failure: the session
+      // is owned by its replacement runner, or by no runner at all. Only the
+      // handle the map currently points at may flip the session to error;
+      // surfacing a replaced runner's abort noise here was wrongly failing
+      // healthy sessions on every reuse-rejected follow-up.
+      if (mappedEntry?.handle !== handle) {
         return;
       }
 

--- a/src/electron/libs/claude-model-selection.ts
+++ b/src/electron/libs/claude-model-selection.ts
@@ -71,6 +71,44 @@ export function toClaudeCodeRuntimeModel(
   return wants1m && supportsClaude1mContext(runtimeAlias) ? `${runtimeAlias}[1m]` : runtimeAlias;
 }
 
+/**
+ * Whether a requested model and a stored/display model refer to the same
+ * effective selection. A bare family alias ('opus') resolves server-side to
+ * the newest concrete model of its family, and session init records the
+ * CLI-reported concrete id back into the session — so the composer's alias
+ * compared against that stored concrete id is NOT a model change (treating
+ * it as one made every follow-up message abort the warm runner and cold
+ * respawn). Two different concrete ids remain a real change; family names
+ * come from CLAUDE_FAMILY_ALIASES (no pinned versions).
+ */
+export function isSameClaudeModelSelection(
+  a?: string | null,
+  b?: string | null
+): boolean {
+  const na = normalizeClaudeRequestedModel(a);
+  const nb = normalizeClaudeRequestedModel(b);
+  if (na === nb) return true;
+  if (!na || !nb) return false;
+  const aliasSide = CLAUDE_FAMILY_ALIASES.has(na)
+    ? na
+    : CLAUDE_FAMILY_ALIASES.has(nb)
+      ? nb
+      : undefined;
+  if (!aliasSide) return false;
+  const concreteSide = aliasSide === na ? nb : na;
+  if (CLAUDE_FAMILY_ALIASES.has(concreteSide)) return false;
+  return claudeModelFamily(concreteSide) === aliasSide;
+}
+
+/** 'claude-opus-4-8' → 'opus'; 'sonnet' → 'sonnet'; unknown shapes → undefined. */
+function claudeModelFamily(model: string): string | undefined {
+  const bare = stripContext1mSuffix(model.trim().toLowerCase());
+  if (CLAUDE_FAMILY_ALIASES.has(bare)) return bare;
+  const familyPattern = new RegExp(`^claude-(${[...CLAUDE_FAMILY_ALIASES].join('|')})\\b`);
+  const match = familyPattern.exec(bare);
+  return match?.[1];
+}
+
 export function reconcileClaudeDisplayModel(
   requestedModel?: string | null,
   runtimeModel?: string | null

--- a/src/electron/libs/runner.ts
+++ b/src/electron/libs/runner.ts
@@ -1170,8 +1170,16 @@ export function runClaude(options: RunnerOptions): RunnerHandle {
         }
       }
     } catch (error: unknown) {
-      // 忽略 abort 错误
-      if (error instanceof Error && error.name === 'AbortError') {
+      // Deliberate aborts are teardown, not failures. The SDK does not
+      // always throw DOMException-style AbortErrors: its transport throws a
+      // plain `Error` subclass with message "Operation aborted" (minified
+      // `ot`), whose name is just 'Error' — and once OUR abort() fired, any
+      // error surfacing from the dying stream is abort noise by definition.
+      if (
+        abortController.signal.aborted ||
+        (error instanceof Error &&
+          (error.name === 'AbortError' || /operation aborted/i.test(error.message)))
+      ) {
         return;
       }
       const err = error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
Fixes a user-reported regression on master (found in real usage after #38/#39 merged): in a plain claude/opus session — no stop pressed, no settings touched — **every** follow-up message logged `[Session Continue] hasExistingRunner: true` then `[Runner Select] hasResume: true` (reuse REJECTED → abort + cold respawn), followed by `Runner error: ot [Error]: Operation aborted` and the session flipping to error.

## Root causes (verified by tracing the exact values)

1. **`modelChanged` fired on every continue for alias-selected models.** Session init overwrites `session.model` with the CLI-resolved concrete id (`reconcileClaudeDisplayModel('opus', 'claude-opus-4-x') → 'claude-opus-4-x'`, ipc-handlers init block), while the composer resends the family alias (`selectedModel = agentSelection.model = 'opus'`). The raw comparison `'opus' !== 'claude-opus-4-x'` rejected reuse every time — and since every respawn re-runs init, it re-armed itself every message. All other gate flags were confirmed false.
2. **The abort swallow missed the SDK's error shape.** `runner.ts` only swallowed `error.name === 'AbortError'`, but the SDK transport throws `new ot('Operation aborted')` where `class ot extends Error {}` — name `'Error'`. Every deliberate `abort()` leaked into `onError`.
3. **onError failed the session from a stale handle.** Only *user-stopped* stale handles were silenced; a handle replaced by the (spurious) reuse rejection fell through to `updateSessionStatus('error')` + toast against the healthy session its replacement was serving.

## Changes

- `isSameClaudeModelSelection` (claude-model-selection.ts): a bare family alias matches a concrete id of its own family (families from the existing `CLAUDE_FAMILY_ALIASES` set — no pinned version lists); two different concrete ids remain a real change. The continue gate uses it for Claude only.
- Broadened abort swallow: name `AbortError`, message `/operation aborted/i`, or our own `abortController.signal.aborted` at catch time.
- onError: a stale (replaced/retired, for any reason) handle can never flip the live session to error — only the currently mapped handle may.
- `[Session Continue]` log now includes `modelChanged` / `executionModeChanged` / `runnerCwdChanged` / `previousModel` / entry `doomed`/`autoApprove`, so the next reuse regression isn't blind.

## Verification

- New `claude-model-selection.test.ts` (regression pair `'opus'` vs `'claude-opus-4-8'`, symmetric, cross-family and concrete-vs-concrete stay changes, word-boundary family matching) wired into `verify:claude-turn-latency`, plus wiring assertions for all three fixes.
- `transpile:electron` clean; all verify suites pass; full `npm test` and `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)