### PR TITLE
style: refine header controls and editor menu

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -993,13 +993,19 @@ export function App() {
                 {sidebarCollapsed ? <SidebarHeaderTrigger className="ml-[72px]" /> : null}
               </div>
               <div className="flex items-center justify-end gap-1 pr-10">
+                <EnvironmentEditorPicker context={environmentContext} />
+                <EnvironmentHub
+                  context={environmentContext}
+                  git={gitEnvironment}
+                  onOpenProjectPanel={openEnvironmentProjectPanel}
+                />
                 <button
                   type="button"
                   onClick={() => {
                     setTerminalDrawerOpen(!terminalDrawerOpen);
                     setTerminalFullscreen(false);
                   }}
-                  className={`no-drag inline-flex h-7 min-w-7 items-center justify-center gap-1 rounded-lg px-1.5 text-[11px] font-medium transition-colors ${
+                  className={`no-drag inline-flex h-7 w-7 items-center justify-center rounded-lg text-[11px] font-medium transition-colors ${
                     terminalDrawerOpen
                       ? 'bg-[var(--sidebar-item-active)] text-[var(--text-primary)]'
                       : 'text-[var(--text-secondary)] hover:bg-[var(--sidebar-item-hover)] hover:text-[var(--text-primary)]'
@@ -1009,12 +1015,6 @@ export function App() {
                 >
                   <BottomTerminalToggleIcon />
                 </button>
-                <EnvironmentEditorPicker context={environmentContext} />
-                <EnvironmentHub
-                  context={environmentContext}
-                  git={gitEnvironment}
-                  onOpenProjectPanel={openEnvironmentProjectPanel}
-                />
               </div>
             </div>
           </div>
@@ -1596,7 +1596,7 @@ function RightPanelToggleIcon() {
       strokeLinejoin="round"
     >
       <rect width="18" height="16" x="3" y="4" rx="4" />
-      <path d="M15 7v10" />
+      <path d="M15 8v8" />
     </svg>
   );
 }
@@ -1614,7 +1614,7 @@ function PanelLauncher({
     <button
       type="button"
       onClick={onToggle}
-      className={`no-drag inline-flex h-7 min-w-7 items-center justify-center rounded-lg px-1.5 text-[11px] font-medium transition-colors ${
+      className={`no-drag inline-flex h-7 w-7 items-center justify-center rounded-lg text-[11px] font-medium transition-colors ${
         active
           ? 'bg-[var(--sidebar-item-active)] text-[var(--text-primary)]'
           : 'text-[var(--text-secondary)] hover:bg-[var(--sidebar-item-hover)] hover:text-[var(--text-primary)]'

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1007,7 +1007,7 @@ export function App() {
                   title="Bottom terminal"
                   aria-label="Toggle bottom terminal drawer"
                 >
-                  <SquareTerminal className="h-[13px] w-[13px] shrink-0" />
+                  <BottomTerminalToggleIcon />
                 </button>
                 <EnvironmentEditorPicker context={environmentContext} />
                 <EnvironmentHub
@@ -1564,6 +1564,24 @@ function RightUtilityTabStrip({
 // board / environment list), but it is intentionally NOT offered in the
 // launcher menu — it only exists when the main agent has spawned subagents.
 type PanelLauncherKind = 'launcher' | 'files' | 'side-chat' | 'browser' | 'review' | 'terminal' | 'subagent';
+
+function BottomTerminalToggleIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-[14px] w-[14px] shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect width="18" height="16" x="3" y="4" rx="4" />
+      <path d="M9 16h6" />
+    </svg>
+  );
+}
 
 function RightPanelToggleIcon() {
   return (

--- a/src/ui/components/environment/EnvironmentHub.tsx
+++ b/src/ui/components/environment/EnvironmentHub.tsx
@@ -161,7 +161,11 @@ export function EnvironmentEditorPicker({ context }: { context: ActiveEnvironmen
     };
   }, []);
 
-  const primaryEditor = editorLaunchers.find((editor) => editor.available) ?? editorLaunchers[0] ?? null;
+  const primaryEditor =
+    editorLaunchers.find((editor) => editor.available && editor.id !== 'finder')
+    ?? editorLaunchers.find((editor) => editor.available)
+    ?? editorLaunchers[0]
+    ?? null;
   const primaryEditorVisual = primaryEditor ? getEditorVisual(primaryEditor) : null;
 
   const openEditor = async (editor: EnvironmentEditorLauncher) => {

--- a/src/ui/components/environment/EnvironmentHub.tsx
+++ b/src/ui/components/environment/EnvironmentHub.tsx
@@ -189,29 +189,48 @@ export function EnvironmentEditorPicker({ context }: { context: ActiveEnvironmen
 
   return (
     <DropdownMenu.Root>
-      <DropdownMenu.Trigger asChild>
+      <div
+        className={`no-drag inline-flex h-6 overflow-hidden rounded-[9px] border border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-secondary)] ${
+          disabled ? 'opacity-45' : ''
+        }`}
+      >
         <button
           type="button"
           disabled={disabled}
-          className={`no-drag inline-flex h-7 min-w-7 items-center justify-center rounded-md px-1.5 text-[11px] font-medium transition-colors ${
-            disabled
-              ? 'cursor-not-allowed opacity-45'
-              : 'cursor-pointer text-[var(--text-secondary)] hover:bg-[var(--sidebar-item-hover)] hover:text-[var(--text-primary)] data-[popup-open]:bg-[var(--sidebar-item-active)] data-[popup-open]:text-[var(--text-primary)]'
+          onClick={() => {
+            if (primaryEditor) void openEditor(primaryEditor);
+          }}
+          className={`inline-flex h-full w-[26px] items-center justify-center transition-colors ${
+            disabled ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--sidebar-item-hover)] hover:text-[var(--text-primary)]'
           }`}
           title={primaryEditor ? `Open in ${primaryEditor.label}` : 'No editor detected'}
-          aria-label="Open workspace in editor"
+          aria-label={primaryEditor ? `Open workspace in ${primaryEditor.label}` : 'No editor detected'}
         >
           {triggerVisual}
         </button>
-      </DropdownMenu.Trigger>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            disabled={disabled}
+            className={`inline-flex h-full w-[18px] items-center justify-center transition-colors ${
+              disabled
+                ? 'cursor-not-allowed'
+                : 'cursor-pointer hover:bg-[var(--sidebar-item-hover)] hover:text-[var(--text-primary)] data-[popup-open]:bg-[var(--sidebar-item-active)] data-[popup-open]:text-[var(--text-primary)]'
+            }`}
+            title="Choose application"
+            aria-label="Choose application to open workspace"
+          >
+            <ChevronDown className="h-3 w-3" />
+          </button>
+        </DropdownMenu.Trigger>
+      </div>
       <DropdownMenu.Portal>
         <DropdownMenu.Content
           align="end"
           sideOffset={6}
-          className="z-[9999] min-w-[200px] rounded-[var(--popover-radius)] border border-[var(--popover-border)] bg-[var(--popover-bg)] p-1 shadow-[var(--popover-shadow)]"
+          className="z-[9999] w-[220px] rounded-[18px] !border-0 bg-[var(--popover-bg)] [background-image:none] p-2 shadow-[0_18px_42px_-12px_rgba(15,23,42,0.16)]"
         >
           <DropdownMenu.Group>
-            <DropdownMenu.Label>Open in…</DropdownMenu.Label>
             {editorLaunchers.map((editor) => {
             const visual = getEditorVisual(editor);
             const itemDisabled = !editor.available || !context.effectiveCwd;
@@ -223,12 +242,12 @@ export function EnvironmentEditorPicker({ context }: { context: ActiveEnvironmen
                   event.preventDefault();
                   void openEditor(editor);
                 }}
-                className="flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-[13px] text-[var(--text-primary)] outline-none data-[disabled]:opacity-45 data-[highlighted]:bg-[var(--sidebar-item-hover)]"
+                className="flex h-9 cursor-default items-center gap-3 rounded-xl px-3 text-[13px] text-[var(--text-primary)] outline-none transition-colors data-[disabled]:opacity-45 data-[highlighted]:bg-[var(--sidebar-item-hover)]"
               >
                 {editor.iconDataUrl ? (
-                  <img src={editor.iconDataUrl} alt="" className="h-4 w-4 shrink-0 rounded-[4px]" />
+                  <img src={editor.iconDataUrl} alt="" className="h-[18px] w-[18px] shrink-0 rounded-[5px]" />
                 ) : (
-                  <span className={`flex h-4 w-4 items-center justify-center rounded-[4px] text-[9px] font-semibold ${visual.tone}`}>
+                  <span className={`flex h-[18px] w-[18px] items-center justify-center rounded-[5px] text-[9px] font-semibold ${visual.tone}`}>
                     {visual.mark}
                   </span>
                 )}
@@ -397,7 +416,7 @@ export function EnvironmentHub({
         ref={triggerRef}
         type="button"
         onClick={() => setOpen((value) => !value)}
-        className={`no-drag relative inline-flex h-7 min-w-7 items-center justify-center rounded-lg px-1.5 text-[11px] font-medium transition-colors ${
+        className={`no-drag relative inline-flex h-7 w-7 items-center justify-center rounded-lg text-[11px] font-medium transition-colors ${
           open
             ? 'bg-[var(--sidebar-item-active)] text-[var(--text-primary)]'
             : 'text-[var(--text-secondary)] hover:bg-[var(--sidebar-item-hover)] hover:text-[var(--text-primary)]'


### PR DESCRIPTION
## What changed

- refine the bottom terminal and right-panel toggle icons to match the reference geometry
- turn the local editor control into a split button with direct-open and application-picker actions
- align header control ordering, sizing, spacing, and hover behavior
- restyle the local application menu with updated dimensions, rounding, item spacing, and shadow treatment

## Why

The existing controls used mismatched icon shapes and a single dropdown action. These changes align the header with the target visual language and separate direct opening from application selection.

## Validation

- `npm run build`